### PR TITLE
Setup and CLI bootstrap fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # ╔══════════════════════════════════════════════════════════════════════╗
 # ║  GTM-OS Environment Variables                                       ║
 # ║  Copy this file to .env.local: cp .env.example .env.local          ║
-# ║  Or run: yalc-gtmstart (guided wizard handles everything)      ║
+# ║  Or run: yalc-gtm start (guided wizard handles everything)     ║
 # ╚══════════════════════════════════════════════════════════════════════╝
 
 # ── REQUIRED ─────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ YALC is an open-source, AI-native operating system for running any GTM campaign.
 
 ## Quick Start
 
+### Prerequisites
+
+- Node.js version 20 or higher ([nodejs.org](https://nodejs.org/))
+- pnpm: run `corepack enable && corepack prepare pnpm@latest --activate` (or see the [pnpm install guide](https://pnpm.io/installation))
+- Git
+
 ```bash
 git clone https://github.com/Othmane-Khadri/YALC-the-GTM-operating-system.git
 cd YALC-the-GTM-operating-system
@@ -22,6 +28,10 @@ pnpm link --global
 # One command to set up everything
 yalc-gtm start
 ```
+
+### If `pnpm link --global` fails
+
+If you see `ERR_PNPM_NO_GLOBAL_BIN_DIR`, or you are on Windows, skip the global link and run YALC in-repo: `pnpm cli start`. This uses the `cli` script defined in `package.json` and works without any global bin directory.
 
 The `start` command walks you through 4 steps:
 

--- a/bin/yalc-gtm.mjs
+++ b/bin/yalc-gtm.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+/**
+ * Portable bin entry for `yalc-gtm`.
+ *
+ * Registers tsx's ESM loader, then imports the TypeScript CLI entry.
+ * Works on Linux, macOS, and Windows without a build step because we
+ * never rely on a shebang inside the .ts file.
+ */
+import { tsImport } from 'tsx/esm/api'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const cliEntry = resolve(here, '../src/cli/index.ts')
+
+await tsImport(cliEntry, import.meta.url)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     ".": "./src/index.ts"
   },
   "bin": {
-    "yalc-gtm": "./src/cli/index.ts"
+    "yalc-gtm": "./bin/yalc-gtm.mjs"
+  },
+  "engines": {
+    "node": ">=20"
   },
   "scripts": {
     "cli": "npx tsx src/cli/index.ts",
@@ -52,6 +55,7 @@
     "drizzle-orm": "^0.45.1",
     "hono": "^4.12.8",
     "js-yaml": "^4.1.1",
+    "tsx": "^4.19.0",
     "unipile-node-sdk": "^1.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       unipile-node-sdk:
         specifier: ^1.0.0
         version: 1.9.3
@@ -65,7 +68,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12))
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12)(tsx@4.21.0))
 
 packages:
 
@@ -98,6 +101,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -107,6 +116,12 @@ packages:
   '@esbuild/android-arm64@0.19.12':
     resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -122,6 +137,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -131,6 +152,12 @@ packages:
   '@esbuild/android-x64@0.19.12':
     resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -146,6 +173,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
@@ -155,6 +188,12 @@ packages:
   '@esbuild/darwin-x64@0.19.12':
     resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -170,6 +209,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
@@ -179,6 +224,12 @@ packages:
   '@esbuild/freebsd-x64@0.19.12':
     resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -194,6 +245,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -203,6 +260,12 @@ packages:
   '@esbuild/linux-arm@0.19.12':
     resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -218,6 +281,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
@@ -227,6 +296,12 @@ packages:
   '@esbuild/linux-loong64@0.19.12':
     resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -242,6 +317,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
@@ -251,6 +332,12 @@ packages:
   '@esbuild/linux-ppc64@0.19.12':
     resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -266,6 +353,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.18.20':
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
@@ -275,6 +368,12 @@ packages:
   '@esbuild/linux-s390x@0.19.12':
     resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -290,6 +389,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.18.20':
     resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
     engines: {node: '>=12'}
@@ -301,6 +412,18 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.18.20':
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
@@ -314,6 +437,18 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.18.20':
     resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
     engines: {node: '>=12'}
@@ -323,6 +458,12 @@ packages:
   '@esbuild/sunos-x64@0.19.12':
     resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -338,6 +479,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.18.20':
     resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
     engines: {node: '>=12'}
@@ -350,6 +497,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
@@ -359,6 +512,12 @@ packages:
   '@esbuild/win32-x64@0.19.12':
     resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1083,6 +1242,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
@@ -1694,6 +1858,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -1921,10 +2090,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
   '@esbuild/android-arm64@0.19.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.18.20':
@@ -1933,10 +2108,16 @@ snapshots:
   '@esbuild/android-arm@0.19.12':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.18.20':
     optional: true
 
   '@esbuild/android-x64@0.19.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.18.20':
@@ -1945,10 +2126,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.19.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
   '@esbuild/darwin-x64@0.19.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.18.20':
@@ -1957,10 +2144,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.19.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-x64@0.19.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.18.20':
@@ -1969,10 +2162,16 @@ snapshots:
   '@esbuild/linux-arm64@0.19.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
   '@esbuild/linux-arm@0.19.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.18.20':
@@ -1981,10 +2180,16 @@ snapshots:
   '@esbuild/linux-ia32@0.19.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
   '@esbuild/linux-loong64@0.19.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.18.20':
@@ -1993,10 +2198,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.19.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
   '@esbuild/linux-ppc64@0.19.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.18.20':
@@ -2005,10 +2216,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.19.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
   '@esbuild/linux-s390x@0.19.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
@@ -2017,10 +2234,22 @@ snapshots:
   '@esbuild/linux-x64@0.19.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/netbsd-x64@0.19.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
@@ -2029,10 +2258,19 @@ snapshots:
   '@esbuild/openbsd-x64@0.19.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
   '@esbuild/sunos-x64@0.19.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
@@ -2041,16 +2279,25 @@ snapshots:
   '@esbuild/win32-arm64@0.19.12':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
   '@esbuild/win32-ia32@0.19.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.19.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@hono/node-server@1.19.11(hono@4.12.8)':
@@ -2403,13 +2650,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12))':
+  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -2689,6 +2936,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.19.12
       '@esbuild/win32-ia32': 0.19.12
       '@esbuild/win32-x64': 0.19.12
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escape-html@1.0.3: {}
 
@@ -3281,6 +3557,13 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -3305,7 +3588,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12):
+  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3316,14 +3599,15 @@ snapshots:
       '@types/node': 20.19.35
       esbuild: 0.19.12
       fsevents: 2.3.3
+      tsx: 4.21.0
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12)):
+  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12))
+      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -3340,7 +3624,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.35)(esbuild@0.19.12)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,17 @@
-#!/usr/bin/env npx tsx
 import { config as loadEnv } from 'dotenv'
-loadEnv({ path: '.env.local' })
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+// Load env from ~/.gtm-os/.env first (canonical), then .env.local in CWD
+// (legacy) as a fallback. dotenv v16.4+ supports an array of paths; later
+// entries do NOT override earlier ones, so the canonical location wins.
+const globalEnvPath = join(homedir(), '.gtm-os', '.env')
+const localEnvPath = join(process.cwd(), '.env.local')
+const envPaths = [globalEnvPath, localEnvPath].filter(existsSync)
+if (envPaths.length > 0) {
+  loadEnv({ path: envPaths })
+}
 
 import { Command } from 'commander'
 import { loadConfig } from '../lib/config/loader'
@@ -47,7 +58,7 @@ program
   .option('--dry-run', 'Show what would happen without sending anything')
   .option('--campaign-id <id>', 'Track a specific campaign only')
   .action(withDiagnostics(async (opts) => {
-    const config = loadConfig(program.opts().config.replace('~', process.env.HOME!))
+    const config = loadConfig(program.opts().config.replace('~', homedir()))
     const { runTracker } = await import('../lib/campaign/tracker')
     await runTracker({
       config,
@@ -73,7 +84,7 @@ program
   .option('--delay-mode <mode>', 'Step delay counting: business or calendar (default: business)')
   .option('--dry-run', 'Preview campaign creation without writing to DB')
   .action(withDiagnostics(async (opts) => {
-    const config = loadConfig(program.opts().config.replace('~', process.env.HOME!))
+    const config = loadConfig(program.opts().config.replace('~', homedir()))
     const { runCreator } = await import('../lib/campaign/creator')
     const { buildScheduleFromOptions } = await import('../lib/campaign/schedule')
 
@@ -162,7 +173,7 @@ program
   .description('Generate weekly intelligence report')
   .option('--week <date>', 'Report week (ISO date, defaults to current)')
   .action(withDiagnostics(async (opts) => {
-    const config = loadConfig(program.opts().config.replace('~', process.env.HOME!))
+    const config = loadConfig(program.opts().config.replace('~', homedir()))
     const { runReport } = await import('../lib/campaign/intelligence-report')
     await runReport({ config, week: opts.week })
   }))
@@ -177,7 +188,7 @@ program
   .option('--output <path>', 'Custom output JSON path')
   .option('--account <name>', 'Unipile account name or ID to use for scraping')
   .action(withDiagnostics(async (opts) => {
-    const config = loadConfig(program.opts().config.replace('~', process.env.HOME!))
+    const config = loadConfig(program.opts().config.replace('~', homedir()))
     const { scrapePostEngagers } = await import('../lib/scraping/post-engagers')
     const result = await scrapePostEngagers({
       config,
@@ -581,7 +592,7 @@ program
   .requiredOption('--provider <name>', 'CRM provider name')
   .option('--dry-run', 'Preview import without writing to DB')
   .action(withDiagnostics(async (opts) => {
-    const config = loadConfig(program.opts().config.replace('~', process.env.HOME!))
+    const config = loadConfig(program.opts().config.replace('~', homedir()))
     const { runImport } = await import('../lib/qualification/importers')
     await runImport({
       config,
@@ -843,7 +854,7 @@ program
   .option('--no-dedup', 'Skip dedup gate entirely')
   .option('--slack-confirm', 'Enable Slack confirmation for ambiguous dedup matches')
   .action(withDiagnostics(async (opts) => {
-    const config = loadConfig(program.opts().config.replace('~', process.env.HOME!))
+    const config = loadConfig(program.opts().config.replace('~', homedir()))
     const { runQualify } = await import('../lib/qualification/pipeline')
     await runQualify({
       config,
@@ -864,7 +875,7 @@ program
   .requiredOption('--input <path>', 'Path to input file')
   .option('--dry-run', 'Preview import without writing to DB')
   .action(withDiagnostics(async (opts) => {
-    const config = loadConfig(program.opts().config.replace('~', process.env.HOME!))
+    const config = loadConfig(program.opts().config.replace('~', homedir()))
     const { runImport } = await import('../lib/qualification/importers')
     await runImport({ config, source: opts.source, input: opts.input, dryRun: opts.dryRun ?? false })
   }))
@@ -877,7 +888,7 @@ program
   .option('--strategy <type>', 'Matcher strategy: exact, fuzzy, or all', 'all')
   .option('--slack-confirm', 'Send Slack confirmations for ambiguous matches')
   .action(withDiagnostics(async (opts) => {
-    const config = loadConfig(program.opts().config.replace('~', process.env.HOME!))
+    const config = loadConfig(program.opts().config.replace('~', homedir()))
     const { DedupEngine } = await import('../lib/dedup/engine')
     const { buildSuppressionSet } = await import('../lib/dedup/live-sync')
     const { sendConfirmation } = await import('../lib/dedup/slack-confirm')
@@ -993,7 +1004,7 @@ program
   .option('--direction <dir>', 'push | pull | both', 'both')
   .option('--dry-run', 'Preview sync without writing')
   .action(withDiagnostics(async (opts) => {
-    const config = loadConfig(program.opts().config.replace('~', process.env.HOME!))
+    const config = loadConfig(program.opts().config.replace('~', homedir()))
     const { runSync } = await import('../lib/notion/sync')
     await runSync({ config, direction: opts.direction, dryRun: opts.dryRun ?? false })
   }))
@@ -1004,7 +1015,7 @@ program
   .description('Import existing campaigns, leads, and variants from Notion into SQLite')
   .option('--dry-run', 'Preview bootstrap without writing to DB')
   .action(withDiagnostics(async (opts) => {
-    const config = loadConfig(program.opts().config.replace('~', process.env.HOME!))
+    const config = loadConfig(program.opts().config.replace('~', homedir()))
     const { runBootstrap } = await import('../lib/notion/bootstrap')
     await runBootstrap({ config, dryRun: opts.dryRun ?? false })
   }))
@@ -1144,7 +1155,7 @@ program
   .description('Run a test batch: find → enrich → qualify → review')
   .option('--count <n>', 'Number of test leads', '10')
   .action(withDiagnostics(async (opts) => {
-    const config = loadConfig(program.opts().config.replace('~', process.env.HOME!))
+    const config = loadConfig(program.opts().config.replace('~', homedir()))
     const { runTestBatch } = await import('../lib/execution/test-runner')
     await runTestBatch(config, parseInt(opts.count, 10))
   }))

--- a/src/lib/onboarding/start.ts
+++ b/src/lib/onboarding/start.ts
@@ -9,7 +9,7 @@
  * Other keys unlock additional capabilities (enrichment, LinkedIn, scraping).
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { randomBytes } from 'node:crypto'
@@ -19,6 +19,7 @@ import { isClaudeCode } from '../env/claude-code.js'
 
 const GTM_OS_DIR = join(homedir(), '.gtm-os')
 const CONFIG_PATH = join(GTM_OS_DIR, 'config.yaml')
+const ENV_PATH = join(GTM_OS_DIR, '.env')
 
 // ─── Provider tiers ─────────────────────────────────────────────────────────
 // Tier 1 = recommended for standalone use. Tier 2 = unlocks core features.
@@ -82,6 +83,11 @@ export async function runStart(opts: StartOptions): Promise<void> {
   const { tenantId } = opts
   const inClaudeCode = isClaudeCode()
 
+  // Apply DB migrations before anything else — fresh installs have no tables
+  // yet, so the first query otherwise crashes with `SQLITE_ERROR: no such table`.
+  // Idempotent: drizzle's migrator is a no-op when everything is current.
+  await applyMigrations()
+
   console.log(`
   ╔══════════════════════════════════════╗
   ║         GTM-OS — Getting Started     ║
@@ -108,11 +114,22 @@ export async function runStart(opts: StartOptions): Promise<void> {
     console.log(`  Created default config`)
   }
 
-  // Read existing .env.local
-  const envLocalPath = join(process.cwd(), '.env.local')
+  // Read existing env. Canonical location is ~/.gtm-os/.env. For back-compat
+  // we also look at ./.env.local in the CWD — if only the legacy file exists,
+  // migrate it to the canonical location and keep the original in place.
+  const legacyEnvPath = join(process.cwd(), '.env.local')
+  const hasGlobalEnv = existsSync(ENV_PATH)
+  const hasLegacyEnv = existsSync(legacyEnvPath)
+
+  if (!hasGlobalEnv && hasLegacyEnv) {
+    copyFileSync(legacyEnvPath, ENV_PATH)
+    console.log(`  Migrated ${legacyEnvPath} → ${ENV_PATH}`)
+  }
+
+  const envReadPath = existsSync(ENV_PATH) ? ENV_PATH : (hasLegacyEnv ? legacyEnvPath : null)
   const existingEnv: Record<string, string> = {}
-  if (existsSync(envLocalPath)) {
-    const content = readFileSync(envLocalPath, 'utf-8')
+  if (envReadPath) {
+    const content = readFileSync(envReadPath, 'utf-8')
     for (const line of content.split('\n')) {
       const match = line.match(/^([A-Z_]+)=(.+)$/)
       if (match) existingEnv[match[1]] = match[2]
@@ -209,12 +226,12 @@ export async function runStart(opts: StartOptions): Promise<void> {
     console.log('    .env.local and re-run `yalc-gtm setup` to validate.')
   }
 
-  // Write .env.local
+  // Write canonical env file at ~/.gtm-os/.env
   const envContent = Object.entries(collectedKeys)
     .map(([k, v]) => `${k}=${v}`)
     .join('\n') + '\n'
-  writeFileSync(envLocalPath, envContent)
-  console.log(`\n  ✓ ${Object.keys(collectedKeys).length} keys saved to .env.local`)
+  writeFileSync(ENV_PATH, envContent)
+  console.log(`\n  ✓ ${Object.keys(collectedKeys).length} keys saved to ${ENV_PATH}`)
 
   // ── Step 2: Company Context ─────────────────────────────────────────────
   console.log('\n── Step 2/4 — Company Context ──\n')
@@ -275,6 +292,44 @@ export async function runStart(opts: StartOptions): Promise<void> {
 
   // ── Readiness Report ────────────────────────────────────────────────────
   printReadinessReport(collectedKeys, { frameworkDerived, inClaudeCode })
+}
+
+/**
+ * Apply pending drizzle migrations. Idempotent: when everything is current
+ * this is a no-op and prints nothing. When it applies migrations, prints
+ * "✓ Database ready".
+ */
+async function applyMigrations(): Promise<void> {
+  const { rawClient, db } = await import('../db/index.js')
+  const { migrate } = await import('drizzle-orm/libsql/migrator')
+  const { fileURLToPath } = await import('node:url')
+  const { dirname, resolve } = await import('node:path')
+
+  const here = dirname(fileURLToPath(import.meta.url))
+  // This file lives at src/lib/onboarding/start.ts → migrations at src/lib/db/migrations
+  const migrationsFolder = resolve(here, '../db/migrations')
+
+  // Count applied migrations before and after to decide whether to log.
+  async function countApplied(): Promise<number> {
+    try {
+      const r = await rawClient.execute(
+        "SELECT COUNT(*) AS n FROM __drizzle_migrations"
+      )
+      const row = r.rows[0] as Record<string, unknown> | undefined
+      const n = row ? Number(row.n ?? 0) : 0
+      return Number.isFinite(n) ? n : 0
+    } catch {
+      return 0 // table doesn't exist yet → first run
+    }
+  }
+
+  const before = await countApplied()
+  await migrate(db, { migrationsFolder })
+  const after = await countApplied()
+
+  if (after > before) {
+    console.log('  ✓ Database ready')
+  }
 }
 
 function printFileStructure(): void {


### PR DESCRIPTION
## Summary

Cleans up the first-run experience so a fresh `git clone → pnpm install → pnpm link --global → yalc-gtm start` flow works on stock macOS, stock Linux, and stock Windows.

### Fixes
- **Portable bin wrapper** at `bin/yalc-gtm.mjs`. Previous bin was a `.ts` file with `#!/usr/bin/env npx tsx`, which fails on Linux GNU `env` (no `-S` split) and has no shebang support on Windows.
- **`tsx` is now a runtime dependency.** It was neither in `dependencies` nor `devDependencies`, so every first run triggered an implicit `npx tsx` install.
- **`engines.node` set to `>=20`** so Node 16/18 users get a clear error instead of a cryptic ESM failure.
- **Env file is now canonical at `~/.gtm-os/.env`.** CLI used to read/write `.env.local` relative to CWD, so keys silently disappeared when users ran commands from any directory other than the one where they ran `start`. Includes a one-time migration from the legacy `./.env.local` if present.
- **DB migrations run automatically** at the top of `runStart`. Previously the schema was never applied, so the first DB-touching command threw `SQLITE_ERROR: no such table`.
- **`process.env.HOME!` replaced with `os.homedir()`** (11 occurrences in `src/cli/index.ts`). Unblocks Windows where the var is `USERPROFILE`.
- **Docs:** README gains a Prerequisites block (Node 20+, pnpm via corepack, Git) and a fallback note pointing to `pnpm cli start` for `ERR_PNPM_NO_GLOBAL_BIN_DIR` / Windows. `.env.example` typo `yalc-gtmstart` → `yalc-gtm start`.

## Test plan

- [x] `pnpm install` resolves, tsx 4.21 added.
- [x] `pnpm typecheck` passes.
- [x] `node bin/yalc-gtm.mjs --help` prints commander help.
- [ ] Fresh-machine smoke test on Linux (not yet run).
- [ ] Fresh-machine smoke test on Windows (not yet run).
- [ ] Verify `~/.gtm-os/.env` migration from a legacy `./.env.local` in an existing install.

## Out of scope

`DEFAULT_CONFIG.data.*` paths in `start.ts` are still CWD-relative. Same class of bug as the old env-file placement, but not onboarding-critical. Left for a follow-up.