### PR TITLE
Bootstrap test database before the suite runs

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ const _testCfg: any = {
   // Vitest 4 moved pool options to top-level.
   forks: { singleFork: true },
   fileParallelism: false,
+  globalSetup: ['./vitest.globalSetup.ts'],
 }
 
 export default defineConfig({

--- a/vitest.globalSetup.ts
+++ b/vitest.globalSetup.ts
@@ -1,0 +1,49 @@
+import { createClient } from '@libsql/client'
+import { spawnSync } from 'node:child_process'
+import { existsSync, unlinkSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+export default async function setup(): Promise<void> {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const testDb = resolve(here, 'gtm-os.test.db')
+
+  for (const suffix of ['', '-shm', '-wal']) {
+    const p = testDb + suffix
+    if (existsSync(p)) unlinkSync(p)
+  }
+
+  process.env.DATABASE_URL = `file:${testDb}`
+
+  const push = spawnSync('pnpm', ['exec', 'drizzle-kit', 'push'], {
+    cwd: here,
+    stdio: 'inherit',
+    env: process.env,
+  })
+  if (push.status !== 0) {
+    throw new Error(`drizzle-kit push failed with exit code ${push.status}`)
+  }
+
+  const migrationsDir = resolve(here, 'src/lib/db/migrations')
+  const files = (await readdir(migrationsDir))
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+  const client = createClient({ url: process.env.DATABASE_URL })
+  for (const f of files) {
+    const sql = await readFile(resolve(migrationsDir, f), 'utf-8')
+    const stmts = sql
+      .split(/-->\s*statement-breakpoint/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+    for (const stmt of stmts) {
+      try {
+        await client.execute(stmt)
+      } catch (err) {
+        const msg = String((err as { message?: string })?.message ?? '')
+        if (!/(already exists|duplicate column)/i.test(msg)) throw err
+      }
+    }
+  }
+  client.close()
+}


### PR DESCRIPTION
## Summary

CI has been red on \`main\` since at least April 16 because the test suite assumes a schema that nothing creates. First DB-touching test throws \`SQLITE_ERROR: no such table\`.

Adds a vitest \`globalSetup\` that:

1. Wipes any previous \`gtm-os.test.db\` so every run starts clean.
2. Points \`DATABASE_URL\` at the isolated test DB so tests never touch the dev DB.
3. Runs \`drizzle-kit push\` to sync the main schema (\`src/lib/db/schema.ts\`).
4. Replays SQL migrations for tables that live outside the main schema (memory layer, signal watches). Duplicate-column / already-exists errors are swallowed so the step is idempotent and order-independent.

## Why not fix the migration journal instead

The repo's \`_journal.json\` only lists \`0000\`, but the filesystem has \`0001\`–\`0003\`. The memory schema also lives in \`src/lib/memory/schema.ts\`, which isn't in \`drizzle.config.ts\`. Regenerating the journal or changing the config has wider blast radius than a test fix should. Those are worth doing as a separate cleanup.

## Test plan

- [x] Local \`pnpm test\` passes (384/384).
- [x] Local \`pnpm typecheck\` passes.
- [ ] Confirm CI turns green once this lands.

## Out of scope

- Backfilling the migration journal.
- Including \`src/lib/memory/schema.ts\` in \`drizzle.config.ts\`.
- Making \`yalc-gtm start\`'s migration step aware of the same memory/signal tables.