### PR TITLE
Schema-driven bootstrap for fresh installs

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from 'drizzle-kit'
 
 export default {
-  schema: './src/lib/db/schema.ts',
+  schema: ['./src/lib/db/schema.ts', './src/lib/memory/schema.ts'],
   out: './src/lib/db/migrations',
   dialect: 'turso',
   dbCredentials: {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "chokidar": "^5.0.0",
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
+    "drizzle-kit": "^0.30.0",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.12.8",
     "js-yaml": "^4.1.1",
@@ -61,7 +62,6 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.17.0",
-    "drizzle-kit": "^0.30.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
+      drizzle-kit:
+        specifier: ^0.30.0
+        version: 0.30.6
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(gel@2.2.0)
@@ -60,9 +63,6 @@ importers:
       '@types/node':
         specifier: ^20.17.0
         version: 20.19.35
-      drizzle-kit:
-        specifier: ^0.30.0
-        version: 0.30.6
       typescript:
         specifier: ^5.7.0
         version: 5.9.3

--- a/src/lib/onboarding/start.ts
+++ b/src/lib/onboarding/start.ts
@@ -295,41 +295,58 @@ export async function runStart(opts: StartOptions): Promise<void> {
 }
 
 /**
- * Apply pending drizzle migrations. Idempotent: when everything is current
- * this is a no-op and prints nothing. When it applies migrations, prints
- * "✓ Database ready".
+ * Bring the database up to the current schema via `drizzle-kit push`.
+ *
+ * We don't use drizzle-orm's journal-based migrator: the repo's journal
+ * only tracks 0000, and schema.ts defines tables (e.g. campaign_variants)
+ * that no migration SQL file creates. Push diffs schema → DB directly, so
+ * it's the only approach that keeps fresh installs and existing dev DBs
+ * in sync with the schema source of truth.
  */
 async function applyMigrations(): Promise<void> {
-  const { rawClient, db } = await import('../db/index.js')
-  const { migrate } = await import('drizzle-orm/libsql/migrator')
+  const { spawn } = await import('node:child_process')
   const { fileURLToPath } = await import('node:url')
   const { dirname, resolve } = await import('node:path')
+  const { existsSync } = await import('node:fs')
+  const { rawClient } = await import('../db/index.js')
+
+  // If the DB already has core tables, the user bootstrapped it previously
+  // (either via a prior run or via `pnpm drizzle-kit push`). Skip — push can
+  // prompt interactively when it detects tables to drop, which would hang
+  // unattended runs.
+  try {
+    const r = await rawClient.execute(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name = 'campaigns' LIMIT 1"
+    )
+    if (r.rows.length > 0) return
+  } catch {
+    // DB file may not exist yet — fall through to push
+  }
 
   const here = dirname(fileURLToPath(import.meta.url))
-  // This file lives at src/lib/onboarding/start.ts → migrations at src/lib/db/migrations
-  const migrationsFolder = resolve(here, '../db/migrations')
+  const pkgRoot = resolve(here, '../../..')
+  const bin = resolve(pkgRoot, 'node_modules/.bin/drizzle-kit')
 
-  // Count applied migrations before and after to decide whether to log.
-  async function countApplied(): Promise<number> {
-    try {
-      const r = await rawClient.execute(
-        "SELECT COUNT(*) AS n FROM __drizzle_migrations"
-      )
-      const row = r.rows[0] as Record<string, unknown> | undefined
-      const n = row ? Number(row.n ?? 0) : 0
-      return Number.isFinite(n) ? n : 0
-    } catch {
-      return 0 // table doesn't exist yet → first run
-    }
+  if (!existsSync(bin)) {
+    console.log('  ⚠ drizzle-kit not found. Run `pnpm install` in the package root, then `pnpm drizzle-kit push`.')
+    return
   }
 
-  const before = await countApplied()
-  await migrate(db, { migrationsFolder })
-  const after = await countApplied()
+  const child = spawn(bin, ['push'], {
+    cwd: pkgRoot,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const chunks: Buffer[] = []
+  child.stdout.on('data', (c) => chunks.push(c))
+  child.stderr.on('data', (c) => chunks.push(c))
+  const code: number = await new Promise((res) => child.on('close', (c) => res(c ?? 0)))
 
-  if (after > before) {
-    console.log('  ✓ Database ready')
+  if (code !== 0) {
+    console.error(Buffer.concat(chunks).toString('utf-8'))
+    throw new Error(`drizzle-kit push failed with exit code ${code}`)
   }
+  console.log('  ✓ Database ready')
 }
 
 function printFileStructure(): void {


### PR DESCRIPTION
## Summary

Fresh \`yalc-gtm start\` runs produced a partial schema and then crashed on the first query. Two causes, one fix.

### What was wrong

1. **Journal out of sync with filesystem.** \`src/lib/db/migrations/meta/_journal.json\` only registers \`0000\`. Files \`0001\`–\`0003\` exist on disk but are never applied by drizzle-orm's journal-based \`migrate()\`. So new users' DBs had no \`tenant_id\` columns, no memory layer, no signal watches.
2. **Schema drift.** \`schema.ts\` defines tables (\`campaign_variants\` is one example) that no migration SQL file creates. Dev DBs only work because someone ran \`drizzle-kit push\` locally, which bypasses the journal and syncs schema.ts directly.

### Fix

Replace the journal-based migration step in \`applyMigrations()\` with a schema-driven one. On first run (DB has no \`campaigns\` table yet) spawn \`drizzle-kit push\`. On subsequent runs the function detects an existing schema and no-ops, so existing dev DBs are untouched. Stdin is closed during push so the command can never block on an interactive prompt.

Also:
- \`drizzle.config.ts\` now includes \`src/lib/memory/schema.ts\` so push sees memory tables.
- \`drizzle-kit\` moved from \`devDependencies\` to \`dependencies\` so it's available to globally linked installs.

### Why not regenerate the migration journal

Regenerating the journal would either (a) invalidate all existing dev DBs that lack \`__drizzle_migrations\` entries, or (b) require a data-migration step to backfill that table. Schema-driven push sidesteps both.

### Test plan

- [x] \`pnpm typecheck\` passes.
- [x] Fresh DB: \`drizzle-kit push\` creates all tables including \`campaign_variants\`, \`memory_nodes\`, \`signal_watches\`, and adds \`tenant_id\` where needed.
- [x] Existing dev DB: push is skipped via the \`campaigns\`-table check; no interactive prompt triggered.
- [ ] End-to-end: fresh clone, \`yalc-gtm start\`, verify DB has complete schema.

### Out of scope

- Cleaning up the orphaned SQL migration files (0001–0003) — they are no longer load-bearing but removing them is a separate decision.
- \`DEFAULT_CONFIG.data.*\` paths in \`start.ts\` are still CWD-relative.