### PR TITLE
Anchor agent logs to home, drop dead data config

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ When YALC detects a parent Claude Code session — via `CLAUDECODE`, `CLAUDE_COD
 ├── qualification_rules.md          Lead qualification patterns (auto-generated)
 ├── campaign_templates.yaml         Outreach copy templates (auto-generated)
 ├── search_queries.txt              Monitoring keywords (auto-generated)
+├── logs/agents/                    Background agent run logs (JSON per run)
 └── tenants/<slug>/                 Per-tenant overrides (multi-company mode)
 
 ./data/                             Working data (in your project directory)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1323,9 +1323,10 @@ program
   .action(async () => {
     const { readdirSync, existsSync } = await import('fs')
     const { join } = await import('path')
+    const { homedir } = await import('os')
     const { AgentLogger } = await import('../lib/agents/logger')
 
-    const logBase = join(process.cwd(), 'data', 'agent-logs')
+    const logBase = join(homedir(), '.gtm-os', 'logs', 'agents')
     if (!existsSync(logBase)) {
       console.log('No agents have been run yet.')
       return

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,6 @@ export type {
   NotionConfig,
   UnipileConfig,
   QualificationConfig,
-  DataConfig,
   CrustdataConfig,
   FullEnrichConfig,
 } from './lib/config/types'

--- a/src/lib/agents/logger.ts
+++ b/src/lib/agents/logger.ts
@@ -3,9 +3,10 @@
 
 import { writeFileSync, mkdirSync, existsSync, readdirSync } from 'fs'
 import { join } from 'path'
+import { homedir } from 'os'
 import type { StepLog, AgentRunLog } from './types'
 
-const LOG_BASE = join(process.cwd(), 'data', 'agent-logs')
+const LOG_BASE = join(homedir(), '.gtm-os', 'logs', 'agents')
 
 export class AgentLogger {
   private agentId: string

--- a/src/lib/config/loader.ts
+++ b/src/lib/config/loader.ts
@@ -24,11 +24,6 @@ const DEFAULTS: GTMOSConfig = {
     disqualifiers_path: '',
     cache_ttl_days: 30,
   },
-  data: {
-    leads_dir: './data/leads',
-    intelligence_dir: './data/intelligence',
-    campaigns_dir: './data/campaigns',
-  },
 }
 
 let _config: GTMOSConfig | null = null
@@ -49,7 +44,6 @@ export function loadConfig(configPath: string): GTMOSConfig {
       },
     },
     qualification: { ...DEFAULTS.qualification, ...parsed.qualification },
-    data: { ...DEFAULTS.data, ...parsed.data },
     crustdata: { max_results_per_query: 50, ...parsed.crustdata },
     fullenrich: { poll_interval_ms: 2000, poll_timeout_ms: 300000, ...parsed.fullenrich },
     instantly: {

--- a/src/lib/config/setup.ts
+++ b/src/lib/config/setup.ts
@@ -39,11 +39,6 @@ const DEFAULT_CONFIG = {
     disqualifiers_path: join(GTM_OS_DIR, 'company_disqualifiers.md'),
     cache_ttl_days: 30,
   },
-  data: {
-    leads_dir: './data/leads',
-    intelligence_dir: './data/intelligence',
-    campaigns_dir: './data/campaigns',
-  },
   crustdata: {
     max_results_per_query: 50,
   },

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -21,12 +21,6 @@ export interface QualificationConfig {
   cache_ttl_days: number
 }
 
-export interface DataConfig {
-  leads_dir: string
-  intelligence_dir: string
-  campaigns_dir: string
-}
-
 export interface CrustdataConfig {
   max_results_per_query: number
 }
@@ -55,7 +49,6 @@ export interface GTMOSConfig {
   notion: NotionConfig
   unipile: UnipileConfig
   qualification: QualificationConfig
-  data: DataConfig
   crustdata?: CrustdataConfig
   fullenrich?: FullEnrichConfig
   instantly?: InstantlyConfig

--- a/src/lib/factory.ts
+++ b/src/lib/factory.ts
@@ -43,11 +43,6 @@ const DEFAULTS: GTMOSConfig = {
     disqualifiers_path: '',
     cache_ttl_days: 30,
   },
-  data: {
-    leads_dir: './data/leads',
-    intelligence_dir: './data/intelligence',
-    campaigns_dir: './data/campaigns',
-  },
 }
 
 /**
@@ -85,7 +80,6 @@ export function createGtmOS(options: GTMOSOptions = {}): GTMOSInstance {
         },
       },
       qualification: { ...config.qualification, ...options.config.qualification },
-      data: { ...config.data, ...options.config.data },
     }
   }
 

--- a/src/lib/onboarding/start.ts
+++ b/src/lib/onboarding/start.ts
@@ -63,11 +63,6 @@ const DEFAULT_CONFIG = {
     disqualifiers_path: join(GTM_OS_DIR, 'company_disqualifiers.md'),
     cache_ttl_days: 30,
   },
-  data: {
-    leads_dir: './data/leads',
-    intelligence_dir: './data/intelligence',
-    campaigns_dir: './data/campaigns',
-  },
   crustdata: { max_results_per_query: 50 },
   fullenrich: { poll_interval_ms: 2000, poll_timeout_ms: 300000 },
 }


### PR DESCRIPTION
## Summary

Two related fixes:

### 1. Agent logs now live under \`~/.gtm-os/logs/agents/\`

Previously \`AgentLogger\` wrote to \`./data/agent-logs/\` resolved against \`process.cwd()\`. That meant running \`yalc-gtm agent:list\` from a directory other than the one where \`agent:run\` was invoked returned \"no agents found\" even when agents had run successfully. Same class of bug as the old \`.env.local\` placement (fixed in PR #3). Now anchored to \`homedir()\` so logs persist across directories.

- \`src/lib/agents/logger.ts\`: \`LOG_BASE\` resolves against \`homedir()\`
- \`src/cli/index.ts\` (agent:list): reads from the same new location

### 2. Drop the dead \`config.data.*\` block

\`GTMOSConfig.data\` was defined in four files (\`config/loader.ts\`, \`config/setup.ts\`, \`factory.ts\`, \`onboarding/start.ts\`) but never read by any code. Removing cleans up the config surface and the \`DataConfig\` interface export.

- \`src/lib/config/types.ts\`: remove \`DataConfig\` interface and \`data\` field from \`GTMOSConfig\`
- \`src/index.ts\`: remove \`DataConfig\` from the public type re-exports
- \`src/lib/config/loader.ts\`, \`src/lib/config/setup.ts\`, \`src/lib/factory.ts\`, \`src/lib/onboarding/start.ts\`: remove the \`data\` block from \`DEFAULTS\` / \`DEFAULT_CONFIG\` and any spread operator

### 3. README file-structure block

Add \`logs/agents/\` under the \`~/.gtm-os/\` map so readers know where agent output goes. Left \`./data/leads/\` \`./data/intelligence/\` \`./data/campaigns/\` untouched: those are user-input directories, not tool output.

## Test plan

- [x] \`pnpm typecheck\` passes
- [x] No residual refs to \`data/agent-logs\`, \`DataConfig\`, or \`config.data\` in \`src/\`
- [ ] From a directory outside the repo: \`yalc-gtm agent:list\` reads logs from the new location