### PR TITLE
Polish for the npm install era

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ You'll end with a readiness report showing what's unlocked and a suggested first
 ### After Setup
 
 ```bash
-# Run your first qualification (dry-run)
-yalc-gtm leads:qualify --source csv --input data/leads/sample.csv --dry-run
+# Easiest: describe what you want in natural language and let YALC plan the work
+yalc-gtm orchestrate "find 10 SaaS CTOs matching my ICP and qualify them"
 
 # Create a campaign
 yalc-gtm campaign:create --title "Q2 Outbound" --hypothesis "VP Eng responds to pain-point messaging"
@@ -62,8 +62,8 @@ yalc-gtm campaign:create --title "Q2 Outbound" --hypothesis "VP Eng responds to 
 # Track campaign progress
 yalc-gtm campaign:track --dry-run
 
-# Or just describe what you want in natural language
-yalc-gtm orchestrate "find 10 companies matching my ICP"
+# Or qualify a lead list you already have (CSV or JSON)
+yalc-gtm leads:qualify --source csv --input ./your-leads.csv --dry-run
 ```
 
 ### Non-Interactive Setup
@@ -73,6 +73,18 @@ For CI or automation, set your keys in `.env.local` (see `.env.example`) and run
 ```bash
 yalc-gtm start --non-interactive
 ```
+
+## Recommended workflow: drive YALC from your IDE chat
+
+YALC is designed to be driven by an AI assistant — Claude Code, Cursor, Copilot, or whatever you have open. Once it's installed globally, you don't need to remember commands. You just talk to your assistant.
+
+Typical flow inside Cursor or VS Code with Claude Code:
+
+1. Install once: `npm i -g yalc-gtm-os`.
+2. Open your IDE and ask in plain language: *"Set up YALC for my company, then find 10 SaaS CTOs and qualify them."*
+3. The assistant runs the commands. Interactive prompts from `start` show up in the same chat panel; you answer them inline.
+
+Every command also works directly in a terminal if you prefer that style. The "Using YALC from Claude Code" section below has the details on how Claude Code integrates with YALC's commands and how the LLM hand-off works when no `ANTHROPIC_API_KEY` is set.
 
 ## Features at a Glance
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,8 +118,8 @@ yalc-gtm campaign:monthly-report
 Run leads through the 7-gate qualification pipeline.
 
 ```bash
-yalc-gtm leads:qualify --source csv --input data/leads/sample.csv --dry-run
-yalc-gtm leads:qualify --source csv --input data/leads/my-leads.csv
+yalc-gtm leads:qualify --source csv --input ./leads.csv --dry-run
+yalc-gtm leads:qualify --source csv --input ./leads.csv
 ```
 
 | Flag | Description |

--- a/docs/first-run.md
+++ b/docs/first-run.md
@@ -126,10 +126,16 @@ At the end, you see what's available based on your configured providers:
 
 ### 1. Qualify Your First Leads
 
-GTM-OS ships with a sample CSV. Run qualification in dry-run mode:
+Already have a lead list? Run qualification in dry-run mode against your CSV:
 
 ```bash
-yalc-gtm leads:qualify --source csv --input data/leads/sample.csv --dry-run
+yalc-gtm leads:qualify --source csv --input ./your-leads.csv --dry-run
+```
+
+Don't have a list yet? Let YALC find and qualify leads for you:
+
+```bash
+yalc-gtm orchestrate "find 10 SaaS CTOs matching my ICP and qualify them"
 ```
 
 This runs each lead through the 7-gate qualification pipeline:
@@ -181,9 +187,8 @@ Claude decomposes this into skills (find-companies → find-people → qualify-l
 ├── search_queries.txt              Monitoring keywords (auto-generated)
 └── tenants/<slug>/                 Per-tenant overrides (multi-company mode)
 
-./data/                             Working data (in your project directory)
-├── leads/                          CSV/JSON lead lists for qualification
-│   └── sample.csv                  Example lead file (ships with repo)
+./data/                             Working data (in your project directory, optional)
+├── leads/                          CSV/JSON lead lists you bring or generate
 ├── intelligence/                   Campaign learnings and insights
 └── campaigns/                      Campaign exports and reports
 ```

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,18 +1,36 @@
 import { execSync } from 'child_process'
-import { resolve } from 'path'
+import { existsSync } from 'fs'
+import { dirname, join, resolve } from 'path'
+import { fileURLToPath } from 'url'
 
 /**
- * Self-update: pull latest code from origin without breaking local config.
- * User data lives in ~/.gtm-os/ (untouched). Only the repo source is updated.
+ * Self-update. Detects how YALC was installed and routes accordingly:
+ * - From source (a .git directory exists at the package root): pull from origin,
+ *   reinstall deps, re-link the CLI globally.
+ * - From npm (no .git): run `npm update -g yalc-gtm-os` so the user gets the
+ *   latest published version.
+ *
+ * User data in ~/.gtm-os/ is never touched.
  */
 export async function runUpdate() {
-  const root = resolve(__dirname, '..', '..', '..')
+  const here = dirname(fileURLToPath(import.meta.url))
+  // src/cli/commands/update.ts → package root is 3 levels up
+  const pkgRoot = resolve(here, '..', '..', '..')
+  const isFromSource = existsSync(join(pkgRoot, '.git'))
+
+  if (isFromSource) {
+    runFromSourceUpdate(pkgRoot)
+  } else {
+    runNpmUpdate()
+  }
+}
+
+function runFromSourceUpdate(root: string) {
   const run = (cmd: string) =>
     execSync(cmd, { cwd: root, encoding: 'utf-8', stdio: 'pipe' }).trim()
 
   const currentCommit = run('git rev-parse --short HEAD')
 
-  // 1. Check for local modifications
   const dirty = run('git status --porcelain')
   const hadStash = dirty.length > 0
 
@@ -21,22 +39,20 @@ export async function runUpdate() {
     run('git stash push -m "yalc-gtm-update-autostash"')
   }
 
-  // 2. Pull latest
   try {
     console.log('[update] Pulling latest from origin...')
     const pullOutput = run('git pull --rebase origin main')
     console.log(`  ${pullOutput}`)
-  } catch (err: any) {
-    // Restore stash before bailing
+  } catch (err: unknown) {
     if (hadStash) {
       try { run('git stash pop') } catch { /* best effort */ }
     }
     console.error('[update] Failed to pull. Check your network or git remote.')
-    console.error(`  ${err.message?.split('\n')[0] ?? err}`)
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`  ${message.split('\n')[0]}`)
     process.exit(1)
   }
 
-  // 3. Install deps (in case package.json changed)
   try {
     console.log('[update] Installing dependencies...')
     run('pnpm install --frozen-lockfile 2>/dev/null || pnpm install')
@@ -44,37 +60,50 @@ export async function runUpdate() {
     console.log('[update] pnpm install had warnings (non-fatal)')
   }
 
-  // 4. Re-link CLI globally
   try {
     run('pnpm link --global')
   } catch {
     // Non-fatal — may already be linked
   }
 
-  // 5. Restore stash
   if (hadStash) {
     try {
       console.log('[update] Restoring your local changes...')
       run('git stash pop')
     } catch {
-      console.warn(
-        '\n⚠  Stash pop had conflicts. Your changes are saved in git stash.',
-      )
+      console.warn('\n⚠  Stash pop had conflicts. Your changes are saved in git stash.')
       console.warn('   Run `git stash show -p` to see them, then resolve manually.')
     }
   }
 
-  // 6. Summary
   const newCommit = run('git rev-parse --short HEAD')
   if (currentCommit === newCommit) {
     console.log(`\n[update] Already up to date (${newCommit}).`)
   } else {
-    // Show what changed
     const log = run(`git log --oneline ${currentCommit}..${newCommit}`)
     const commitCount = log.split('\n').filter(Boolean).length
     console.log(`\n[update] Updated ${currentCommit} → ${newCommit} (${commitCount} new commit${commitCount === 1 ? '' : 's'})`)
-    console.log(log.split('\n').map(l => `  ${l}`).join('\n'))
+    console.log(log.split('\n').map((l) => `  ${l}`).join('\n'))
   }
 
   console.log('[update] Your ~/.gtm-os/ config is untouched.')
+}
+
+function runNpmUpdate() {
+  console.log('[update] Detected npm-installed YALC. Pulling the latest published version...')
+  try {
+    execSync('npm update -g yalc-gtm-os', { stdio: 'inherit' })
+  } catch {
+    // Some npm versions don't move the global pin with `npm update`. Fall back.
+    console.log('[update] Falling back to `npm install -g yalc-gtm-os@latest`...')
+    try {
+      execSync('npm install -g yalc-gtm-os@latest', { stdio: 'inherit' })
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error('[update] npm update failed.')
+      console.error(`  ${message.split('\n')[0]}`)
+      process.exit(1)
+    }
+  }
+  console.log('[update] Done. Your ~/.gtm-os/ config is untouched.')
 }

--- a/src/lib/onboarding/start.ts
+++ b/src/lib/onboarding/start.ts
@@ -561,7 +561,7 @@ function printReadinessReport(
 
   const capabilities: Array<{ check: boolean; label: string; command: string }> = [
     { check: hasAnthropic, label: 'AI-powered GTM planning', command: 'yalc-gtm orchestrate "find companies matching my ICP"' },
-    { check: hasAnthropic && has('CRUSTDATA_API_KEY'), label: 'Lead qualification', command: 'yalc-gtm leads:qualify --source csv --input data/leads/sample.csv --dry-run' },
+    { check: hasAnthropic && has('CRUSTDATA_API_KEY'), label: 'Lead qualification', command: 'yalc-gtm leads:qualify --source csv --input ./your-leads.csv --dry-run' },
     { check: has('UNIPILE_API_KEY'), label: 'LinkedIn campaigns', command: 'yalc-gtm campaign:create --title "First Campaign"' },
     { check: has('NOTION_API_KEY'), label: 'Notion CRM sync', command: 'yalc-gtm notion:sync' },
     { check: has('FIRECRAWL_API_KEY') || state.inClaudeCode, label: 'Web intelligence', command: 'yalc-gtm orchestrate "research competitors"' },
@@ -585,7 +585,7 @@ function printReadinessReport(
   // we can only safely recommend pure-CRUD commands.
   const firstAction = hasAnthropic
     ? capabilities.find(c => c.check)
-    : { command: 'yalc-gtm leads:import --source csv --input data/leads/sample.csv --dry-run' }
+    : { command: 'yalc-gtm campaign:create --title "First Campaign" --hypothesis "test"' }
   if (firstAction) {
     console.log(`  Try this first:
     ${firstAction.command}


### PR DESCRIPTION
## Summary

Three follow-ups to the npm publish so the docs and built-in commands match what npm-installed users actually have.

### Changes

**\`yalc-gtm update\` is now install-aware.** Detects \`.git\` at the package root.
- From a git clone: keep the existing pull + reinstall + relink flow.
- From an npm install: run \`npm update -g yalc-gtm-os\` (falls back to \`npm i -g yalc-gtm-os@latest\` if the global pin isn't moved).

User data in \`~/.gtm-os/\` is untouched in either path.

**Drop \`data/leads/sample.csv\` references.** That sample ships in the GitHub repo but is excluded from the npm tarball, so npm users hit \"file not found\" on the previous example. Updated four locations:
- \`README.md\` Quick Start \"After Setup\" — leads with \`orchestrate\` (no file needed) and shows BYO CSV (\`./your-leads.csv\`) as the alternative.
- \`docs/first-run.md\` — same treatment plus a small file-tree caption fix.
- \`docs/commands.md\` — example uses \`./leads.csv\` as a generic placeholder.
- \`src/lib/onboarding/start.ts\` — post-onboarding tips no longer point to the missing sample.

**New \"Recommended workflow\" section in README.** Frames YALC as chat-driven via Claude Code / Cursor / IDE assistants. Sits between Quick Start and Features at a Glance so first-time visitors see the recommended path before the feature list. Existing \"Using YALC from Claude Code\" deep-dive section stays where it is.

## Test plan

- [x] \`pnpm typecheck\` passes.
- [x] \`pnpm test\` passes (411/411).
- [ ] Sandbox smoke test: \`npm pack\` then install in an isolated HOME, run \`yalc-gtm update\` and confirm it routes to npm rather than git.
- [ ] From-source check: from \`~/Desktop/gtm-os\`, \`yalc-gtm update\` still triggers the git flow.

## Out of scope

- Bundling a sample CSV inside the npm package (real users bring their own data).
- Hard Node version check, surfacing \`doctor\` more aggressively, automated publishing via \`NPM_TOKEN\`. Deferred.