### PR TITLE
feat: multi-step declarative adapters + Explorium provider (4 capabilities)

### DIFF
--- a/docs/superpowers/specs/2026-05-01-declarative-adapters-design.md
+++ b/docs/superpowers/specs/2026-05-01-declarative-adapters-design.md
@@ -22,14 +22,15 @@ Manifests live at `~/.gtm-os/adapters/<capability>-<provider>.yaml`. One file pe
 - `provider`: provider id, unique per capability.
 - `version`: adapter semver, bumped on each manifest edit.
 - `auth`: `{ type: header|query|bearer, name, value }`. `value` uses `${env:VAR}` interpolation.
-- `endpoint`: `{ method, url, queryTemplate? }`. URL supports `{{var}}` from a merged scope.
-- `request` (optional): `{ headers?, bodyTemplate?, contentType? }`. Body is JSON with placeholders. Omit for GET.
-- `response`: `{ rootPath, mappings, errorEnvelope }`. `mappings` projects raw fields onto the capability's output schema.
-- `pagination` (optional): `{ style: cursor|page, pageParam, cursorPath, limit }`. Compiler walks pages until `limit` items collected.
+- `endpoint`: `{ method, url, queryTemplate? }`. URL supports `{{var}}` from a merged scope. Required for single-step manifests; mutually exclusive with `steps`.
+- `request` (optional): `{ headers?, bodyTemplate?, contentType? }`. Body is JSON with placeholders. Omit for GET. Mutually exclusive with `steps`.
+- `response`: `{ rootPath, mappings, errorEnvelope }`. `mappings` projects raw fields onto the capability's output schema. Required for single-step manifests; mutually exclusive with `steps`.
+- `steps` (optional): `[{ id, endpoint, request?, response }]`. **Multi-step manifests** chain HTTP calls; each step's projected output is exposed to subsequent steps via `{{steps.<id>.<path>}}`. Required when the vendor flow needs match-then-enrich (e.g. Explorium prospect contact lookup). Mutually exclusive with top-level `endpoint`/`request`/`response`. Pagination is not supported on multi-step manifests in v1.
+- `pagination` (optional, single-step only): `{ style: cursor|page, pageParam, cursorPath, limit }`. Compiler walks pages until `limit` items collected.
 - `rateLimit` (optional): `{ rps?, retry: { on: [429, 503], backoff: exponential, maxAttempts: 3 } }`.
 - `smoke_test`: `{ input, expectNonEmpty: [paths] }`. Run by the provider-builder skill before registration.
 
-Templates use Mustache-flavour `{{var}}` against a merged scope: `input.*`, `env.*` (whitelisted), `auth.*`. Unknown placeholders are a compile error.
+Templates use Mustache-flavour `{{var}}` against a merged scope: `input.*`, `env.*` (whitelisted), `auth.*`, and — inside multi-step manifests — `steps.<id>.*` for prior step output. Unknown placeholders are a compile error.
 
 ### Example A — `icp-company-search` via Apollo
 
@@ -153,6 +154,69 @@ smoke_test:
     slug: "yalc-smoke"
   expectNonEmpty: [url]
 ```
+
+### Example D — `people-enrich` via Explorium (multi-step: match → enrich)
+
+Vendors like Explorium split person resolution into two endpoints: `POST /v1/prospects/match` returns an internal `prospect_id`, and `POST /v1/prospects/contacts_information/enrich` returns email + phone for that id. The `steps` array threads the first step's output into the second via `{{steps.match.prospect_id}}`. The final step's projected output is what `invoke()` returns.
+
+```yaml
+manifestVersion: 1
+capability: people-enrich
+provider: explorium
+version: 0.2.0
+auth:
+  type: header
+  name: api_key
+  value: ${env:EXPLORIUM_API_KEY}
+steps:
+  - id: match
+    endpoint:
+      method: POST
+      url: https://api.explorium.ai/v1/prospects/match
+    request:
+      contentType: application/json
+      bodyTemplate: |
+        {
+          "prospects_to_match": [
+            { "email": "{{input.contacts[0].email}}",
+              "linkedin": "{{input.contacts[0].linkedin_url}}" }
+          ]
+        }
+    response:
+      rootPath: matched_prospects[0]
+      mappings:
+        "prospect_id": "$.prospect_id"
+      errorEnvelope:
+        matchPath: $.details
+        messagePath: $.details
+  - id: enrich
+    endpoint:
+      method: POST
+      url: https://api.explorium.ai/v1/prospects/contacts_information/enrich
+    request:
+      contentType: application/json
+      bodyTemplate: |
+        { "prospect_id": "{{steps.match.prospect_id}}" }
+    response:
+      rootPath: data
+      mappings:
+        "results[].email": "$.professional_email"
+        "results[].phone": "$.mobile_phone"
+smoke_test:
+  input:
+    contacts:
+      - email: marc@salesforce.com
+  expectNonEmpty: ["results[0].email"]
+```
+
+**Multi-step semantics:**
+
+- Steps execute sequentially. Each step's projection is stored at `scope.steps.<id>` and is visible to all later steps (and only later steps).
+- The auth block applies to every step. There is one auth header set; per-step auth overrides are not supported in v1.
+- If any step's HTTP response is non-2xx OR matches its `errorEnvelope`, the chain aborts with `ProviderApiError` and no later steps run.
+- Step ids must be unique within a manifest (`^[a-zA-Z_][a-zA-Z0-9_]*$`). Duplicate ids fail at runtime with a clear error.
+- `pagination` is incompatible with `steps` in v1 — paginate the final fetch with cursors in your application code if needed.
+- Loops, conditionals, and `Promise.all`-style fan-out are out of scope. The DSL is a linear chain.
 
 ## 2. Runtime compilation
 

--- a/providers/CONTRIBUTING.md
+++ b/providers/CONTRIBUTING.md
@@ -22,9 +22,12 @@ A manifest is a single YAML file that declares:
 - `manifestVersion: 1`
 - `capability: <slug>` and `provider: <slug>` (must match the directory and filename)
 - `auth` block (`header`, `query`, `bearer`, or `none`)
-- `endpoint` (HTTP method + URL with `{{input.*}}` / `${env:VAR}` placeholders)
-- `request` (body template, content-type, optional headers)
-- `response.mappings` projecting vendor JSON onto the capability output schema
+- **Either** a single-call shape:
+  - `endpoint` (HTTP method + URL with `{{input.*}}` / `${env:VAR}` placeholders)
+  - `request` (body template, content-type, optional headers)
+  - `response.mappings` projecting vendor JSON onto the capability output schema
+- **Or** a multi-step shape (when the vendor flow needs match-then-enrich):
+  - `steps: [{ id, endpoint, request?, response }, ...]` — each step's projected output is exposed to later steps via `{{steps.<id>.<path>}}`. The final step's projection is what the adapter returns. See `people-enrich/explorium.yaml` for a worked example.
 - `smoke_test` (a single input that should produce non-empty paths in the output)
 
 Don't inline secrets. All credentials reference env vars via `${env:NAME}`.
@@ -65,9 +68,10 @@ A PR cannot merge until every box below is ticked. The PR template (auto-loaded 
 ## What we won't merge
 
 - Manifests that reach a vendor without static API-key auth (OAuth flows are on the engine's roadmap, not v1 of the DSL).
-- Manifests that try to express multi-step flows (call `/token` then `/search`). The DSL is one HTTP call per execute by design.
 - Manifests with hard-coded test credentials.
 - Manifests that duplicate an entry already on `main` without a clear reason.
+
+Multi-step flows (e.g. match → enrich) ARE supported via the `steps` array. Loops, conditionals, and parallel fan-out are out of scope; the chain is strictly linear.
 
 ## Reporting a problem
 

--- a/providers/manifests/business-enrich/explorium.yaml
+++ b/providers/manifests/business-enrich/explorium.yaml
@@ -1,36 +1,28 @@
 # Explorium AgentSource — business-enrich
 #
-# Vendor docs: https://docs.explorium.ai/reference/businesses/fetch_businesses
-# Endpoint:    POST /v1/businesses
-# Auth:        api_key header (static — no OAuth)
+# Vendor docs:
+#   https://docs.explorium.ai/reference/businesses/match_businesses
+#   https://docs.explorium.ai/reference/businesses/enrichments/firmographics
+# Endpoints:
+#   1. POST /v1/businesses/match                                → business_id
+#   2. POST /v1/businesses/firmographics/enrich                 → firmographics
+# Auth:    api_key header (static — no OAuth)
 #
-# Resolves a company name (and optionally domain) to a full firmographic
-# profile in a single call. Filters the Explorium business database by
-# company name (fuzzy-matched) and returns the top result's enriched record.
+# Resolves a company (by name + domain) to an Explorium business_id, then
+# fetches the firmographic profile (industry, headcount, revenue range, HQ
+# location, description, LinkedIn URL, ticker, NAICS).
 #
-# Design rationale — why POST /v1/businesses instead of match + enrich:
-#   Explorium's canonical enrichment pattern is two calls:
-#     1. POST /v1/businesses/match → business_id
-#     2. POST /v1/businesses/{id}/enrichments/firmographics → fields
-#   The declarative DSL (v1) supports one HTTP call per adapter, so we use
-#   the search endpoint with company_name filter + page_size: 1 to retrieve
-#   the top matching company's full firmographic record in mode: "full".
-#   This avoids the two-step pattern at the cost of relying on search
-#   ranking rather than exact ID resolution. For most use cases (known
-#   company name) the top result is correct. When domain is also provided,
-#   callers should add a website_keywords filter as a secondary signal
-#   (see v1.1 follow-up note).
-#   True match-then-enrich (more accurate for ambiguous names) requires
-#   DSL multi-step support planned for v2.
+# Uses the multi-step DSL: the match step's projected `business_id` is
+# threaded into the firmographics step via {{steps.match.business_id}}.
 #
-# NOTE: This manifest targets the proposed `business-enrich` capability
-# which is not yet declared in the YALC engine. This PR is intentionally
-# opened as a DRAFT. A companion engine PR must:
-#   1. Register the `business-enrich` capability in
-#      src/lib/providers/adapters/index.ts with the schema below.
-#   2. Add `explorium` to that capability's defaultPriority list.
+# NOTE: This manifest targets the proposed `business-enrich` capability,
+# which is not yet declared in the YALC engine. This PR is opened as a
+# DRAFT pending a companion engine PR that:
+#   1. Registers `business-enrich` in src/lib/providers/adapters/index.ts
+#      with the input/output schema described below.
+#   2. Adds `explorium` to its defaultPriority list.
 #
-# Proposed capability schema (for the engine PR):
+# Proposed capability schema:
 #
 #   id: business-enrich
 #   description: >
@@ -38,53 +30,81 @@
 #     profile: industry, headcount, revenue range, HQ country, description,
 #     and Explorium business_id for downstream enrichment calls.
 #   inputSchema:
-#     name:   string  — company name (required; fuzzy matched)
-#     domain: string  — company website/domain (optional; narrows search)
+#     name:   string  — company name (required)
+#     domain: string  — company website/domain (optional, improves accuracy)
 #   outputSchema:
 #     company.name
 #     company.domain
+#     company.linkedin_url
 #     company.industry
 #     company.headcount
 #     company.revenue_range
 #     company.country
 #     company.description
+#     company.naics
+#     company.ticker
 #     company.business_id   — Explorium ID for downstream enrichment calls
 manifestVersion: 1
 capability: business-enrich
 provider: explorium
-version: 0.1.0
+version: 0.2.0
 auth:
   type: header
   name: api_key
   value: ${env:EXPLORIUM_API_KEY}
-endpoint:
-  method: POST
-  url: https://api.explorium.ai/v1/businesses
-request:
-  contentType: application/json
-  bodyTemplate: |
-    {
-      "mode": "full",
-      "page_size": 1,
-      "size": 1,
-      "filters": {
-        "company_name": {"values": ["{{input.name}}"]}
-      }
-    }
-response:
-  rootPath: data
-  mappings:
-    "company.name": "$[0].name"
-    "company.domain": "$[0].website"
-    "company.industry": "$[0].linkedin_industry_category"
-    "company.headcount": "$[0].number_of_employees_range"
-    "company.revenue_range": "$[0].yearly_revenue_range"
-    "company.country": "$[0].country_name"
-    "company.description": "$[0].business_description"
-    "company.business_id": "$[0].business_id"
-  errorEnvelope:
-    matchPath: $.details
-    messagePath: $.details
+steps:
+  # Step 1: resolve the company name + domain to an Explorium business_id.
+  - id: match
+    endpoint:
+      method: POST
+      url: https://api.explorium.ai/v1/businesses/match
+    request:
+      contentType: application/json
+      bodyTemplate: |
+        {
+          "businesses_to_match": [
+            {
+              "name": "{{input.name}}",
+              "domain": "{{input.domain}}"
+            }
+          ]
+        }
+    response:
+      rootPath: matched_businesses[0]
+      mappings:
+        "business_id": "$.business_id"
+      errorEnvelope:
+        matchPath: $.details
+        messagePath: $.details
+
+  # Step 2: fetch firmographics for the resolved business_id.
+  - id: enrich
+    endpoint:
+      method: POST
+      url: https://api.explorium.ai/v1/businesses/firmographics/enrich
+    request:
+      contentType: application/json
+      bodyTemplate: |
+        {
+          "business_id": "{{steps.match.business_id}}"
+        }
+    response:
+      rootPath: data[0]
+      mappings:
+        "company.name": "$.name"
+        "company.domain": "$.website"
+        "company.linkedin_url": "$.linkedin_profile"
+        "company.industry": "$.linkedin_industry_category"
+        "company.headcount": "$.number_of_employees_range"
+        "company.revenue_range": "$.yearly_revenue_range"
+        "company.country": "$.country_name"
+        "company.description": "$.business_description"
+        "company.naics": "$.naics"
+        "company.ticker": "$.ticker"
+        "company.business_id": "$.business_id"
+      errorEnvelope:
+        matchPath: $.details
+        messagePath: $.details
 smoke_test:
   input:
     name: "Salesforce"

--- a/providers/manifests/business-enrich/explorium.yaml
+++ b/providers/manifests/business-enrich/explorium.yaml
@@ -1,0 +1,94 @@
+# Explorium AgentSource — business-enrich
+#
+# Vendor docs: https://docs.explorium.ai/reference/businesses/fetch_businesses
+# Endpoint:    POST /v1/businesses
+# Auth:        api_key header (static — no OAuth)
+#
+# Resolves a company name (and optionally domain) to a full firmographic
+# profile in a single call. Filters the Explorium business database by
+# company name (fuzzy-matched) and returns the top result's enriched record.
+#
+# Design rationale — why POST /v1/businesses instead of match + enrich:
+#   Explorium's canonical enrichment pattern is two calls:
+#     1. POST /v1/businesses/match → business_id
+#     2. POST /v1/businesses/{id}/enrichments/firmographics → fields
+#   The declarative DSL (v1) supports one HTTP call per adapter, so we use
+#   the search endpoint with company_name filter + page_size: 1 to retrieve
+#   the top matching company's full firmographic record in mode: "full".
+#   This avoids the two-step pattern at the cost of relying on search
+#   ranking rather than exact ID resolution. For most use cases (known
+#   company name) the top result is correct. When domain is also provided,
+#   callers should add a website_keywords filter as a secondary signal
+#   (see v1.1 follow-up note).
+#   True match-then-enrich (more accurate for ambiguous names) requires
+#   DSL multi-step support planned for v2.
+#
+# NOTE: This manifest targets the proposed `business-enrich` capability
+# which is not yet declared in the YALC engine. This PR is intentionally
+# opened as a DRAFT. A companion engine PR must:
+#   1. Register the `business-enrich` capability in
+#      src/lib/providers/adapters/index.ts with the schema below.
+#   2. Add `explorium` to that capability's defaultPriority list.
+#
+# Proposed capability schema (for the engine PR):
+#
+#   id: business-enrich
+#   description: >
+#     Resolve a company name (and optional domain) to a rich firmographic
+#     profile: industry, headcount, revenue range, HQ country, description,
+#     and Explorium business_id for downstream enrichment calls.
+#   inputSchema:
+#     name:   string  — company name (required; fuzzy matched)
+#     domain: string  — company website/domain (optional; narrows search)
+#   outputSchema:
+#     company.name
+#     company.domain
+#     company.industry
+#     company.headcount
+#     company.revenue_range
+#     company.country
+#     company.description
+#     company.business_id   — Explorium ID for downstream enrichment calls
+manifestVersion: 1
+capability: business-enrich
+provider: explorium
+version: 0.1.0
+auth:
+  type: header
+  name: api_key
+  value: ${env:EXPLORIUM_API_KEY}
+endpoint:
+  method: POST
+  url: https://api.explorium.ai/v1/businesses
+request:
+  contentType: application/json
+  bodyTemplate: |
+    {
+      "mode": "full",
+      "page_size": 1,
+      "size": 1,
+      "filters": {
+        "company_name": {"values": ["{{input.name}}"]}
+      }
+    }
+response:
+  rootPath: data
+  mappings:
+    "company.name": "$[0].name"
+    "company.domain": "$[0].website"
+    "company.industry": "$[0].linkedin_industry_category"
+    "company.headcount": "$[0].number_of_employees_range"
+    "company.revenue_range": "$[0].yearly_revenue_range"
+    "company.country": "$[0].country_name"
+    "company.description": "$[0].business_description"
+    "company.business_id": "$[0].business_id"
+  errorEnvelope:
+    matchPath: $.details
+    messagePath: $.details
+smoke_test:
+  input:
+    name: "Salesforce"
+    domain: "salesforce.com"
+  expectNonEmpty:
+    - "company.name"
+    - "company.business_id"

--- a/providers/manifests/icp-company-search/explorium.yaml
+++ b/providers/manifests/icp-company-search/explorium.yaml
@@ -1,0 +1,74 @@
+# Explorium AgentSource — icp-company-search
+#
+# Vendor docs: https://docs.explorium.ai/reference/businesses/fetch_businesses
+# Endpoint:    POST /v1/businesses
+# Auth:        api_key header (static — no OAuth)
+#
+# Searches Explorium's 80M+ company database across 150+ countries using
+# ICP-style filters. Maps YALC's standard icp-company-search input onto
+# Explorium's filter schema and normalises the response to companies[].
+#
+# Field mapping notes:
+#   * input.industry     → linkedin_category filter. Accepts free-text
+#                          LinkedIn® industry labels (e.g. "Software development",
+#                          "Investment banking"). Run the Explorium autocomplete
+#                          endpoint for validated category values.
+#   * input.employeeRange → company_size filter. Must be one of the enumerated
+#                          ranges: "1-10", "11-50", "51-200", "201-500",
+#                          "501-1000", "1001-5000", "5001-10000", "10001+".
+#   * input.location     → company_country_code filter. Expects an ISO Alpha-2
+#                          code (e.g. "US", "DE", "IL"). Note: Apollo accepts
+#                          free-text; Explorium requires the ISO code.
+#   * input.keywords     → website_keywords filter. OR-matched across company
+#                          website content — broad discovery, not taxonomy-exact.
+#
+# v1 scope: page 1 only; up to `limit` results (max 500 per Explorium page).
+# Empty filter strings are included in the body; Explorium ignores values []
+# containing only empty strings rather than erroring — verified in smoke run.
+# Multi-filter arrays and cursor pagination are a v1.1 follow-up.
+manifestVersion: 1
+capability: icp-company-search
+provider: explorium
+version: 0.1.0
+auth:
+  type: header
+  name: api_key
+  value: ${env:EXPLORIUM_API_KEY}
+endpoint:
+  method: POST
+  url: https://api.explorium.ai/v1/businesses
+request:
+  contentType: application/json
+  bodyTemplate: |
+    {
+      "mode": "full",
+      "page_size": 25,
+      "size": 25,
+      "filters": {
+        "linkedin_category": {"values": ["{{input.industry}}"]},
+        "company_size": {"values": ["{{input.employeeRange}}"]},
+        "company_country_code": {"values": ["{{input.location}}"]},
+        "website_keywords": {"values": ["{{input.keywords}}"]}
+      }
+    }
+response:
+  rootPath: data
+  mappings:
+    "companies[].name": "$.name"
+    "companies[].domain": "$.website"
+    "companies[].linkedin_url": "$.linkedin_profile"
+    "companies[].headcount": "$.number_of_employees_range"
+    "companies[].industry": "$.linkedin_industry_category"
+  errorEnvelope:
+    matchPath: $.details
+    messagePath: $.details
+smoke_test:
+  input:
+    industry: "Software development"
+    employeeRange: "11-50"
+    location: "US"
+    keywords: "saas"
+    limit: 5
+  expectNonEmpty:
+    - "companies[0].name"
+    - "companies[0].domain"

--- a/providers/manifests/icp-prospect-search/explorium.yaml
+++ b/providers/manifests/icp-prospect-search/explorium.yaml
@@ -1,0 +1,104 @@
+# Explorium AgentSource — icp-prospect-search
+#
+# Vendor docs: https://docs.explorium.ai/reference/prospects/fetch_prospects
+# Endpoint:    POST /v1/prospects
+# Auth:        api_key header (static — no OAuth)
+#
+# Searches Explorium's people database using job- and company-level ICP
+# filters. Returns prospect records with name, title, company, and LinkedIn
+# URL. Contact details (email, phone) are not returned by this endpoint —
+# use the people-enrich adapter to resolve prospect_ids, then call the
+# contacts_information endpoint for verified contact data.
+#
+# NOTE: This manifest targets the proposed `icp-prospect-search` capability
+# which is not yet declared in the YALC engine. This PR is intentionally
+# opened as a DRAFT. A companion engine PR must:
+#   1. Register the `icp-prospect-search` capability in
+#      src/lib/providers/adapters/index.ts with the input/output schema
+#      described below.
+#   2. Add `explorium` to that capability's defaultPriority list.
+#
+# Proposed capability schema (for the engine PR):
+#
+#   id: icp-prospect-search
+#   description: >
+#     Find prospects by job-level, department, company criteria, and
+#     location. Returns a list of people with name, title, company,
+#     and LinkedIn URL. Does not return contact details.
+#   inputSchema:
+#     company_name: string   — target company (free text, fuzzy matched)
+#     job_level:    string   — seniority: "c-suite", "director", "manager",
+#                              "vice president", "founder", "senior manager",
+#                              "owner", "partner", "board member"
+#     department:   string   — dept: "engineering", "sales", "marketing",
+#                              "finance", "operations", "human resources", etc.
+#     country_code: string   — prospect country, ISO Alpha-2 (e.g. "US")
+#     company_country_code: string — company HQ country, ISO Alpha-2
+#     has_email:    boolean  — filter to prospects with a known email address
+#     limit:        number   — max prospects to return
+#   outputSchema:
+#     prospects[].firstname
+#     prospects[].lastname
+#     prospects[].title
+#     prospects[].company
+#     prospects[].linkedin_url
+#     prospects[].prospect_id  — Explorium internal ID for downstream enrichment
+#
+# Field mapping notes:
+#   * input.company_name    → company_name filter (fuzzy matched by Explorium)
+#   * input.job_level       → job_level filter (use Explorium-documented values)
+#   * input.department      → job_department filter
+#   * input.country_code    → country_code filter (prospect's own location, ISO-2)
+#   * input.company_country_code → company_country_code filter (company HQ, ISO-2)
+#   * input.has_email       → has_email filter (true/false)
+manifestVersion: 1
+capability: icp-prospect-search
+provider: explorium
+version: 0.1.0
+auth:
+  type: header
+  name: api_key
+  value: ${env:EXPLORIUM_API_KEY}
+endpoint:
+  method: POST
+  url: https://api.explorium.ai/v1/prospects
+request:
+  contentType: application/json
+  bodyTemplate: |
+    {
+      "mode": "full",
+      "page_size": 25,
+      "size": 25,
+      "filters": {
+        "company_name": {"values": ["{{input.company_name}}"]},
+        "job_level": {"values": ["{{input.job_level}}"]},
+        "job_department": {"values": ["{{input.department}}"]},
+        "country_code": {"values": ["{{input.country_code}}"]},
+        "company_country_code": {"values": ["{{input.company_country_code}}"]},
+        "has_email": {"value": {{input.has_email}}}
+      }
+    }
+response:
+  rootPath: data
+  mappings:
+    "prospects[].firstname": "$.first_name"
+    "prospects[].lastname": "$.last_name"
+    "prospects[].title": "$.job_title"
+    "prospects[].company": "$.company_name"
+    "prospects[].linkedin_url": "$.linkedin_url"
+    "prospects[].prospect_id": "$.prospect_id"
+  errorEnvelope:
+    matchPath: $.details
+    messagePath: $.details
+smoke_test:
+  input:
+    company_name: "Salesforce"
+    job_level: "c-suite"
+    department: "sales"
+    country_code: "US"
+    company_country_code: "US"
+    has_email: true
+    limit: 5
+  expectNonEmpty:
+    - "prospects[0].prospect_id"
+    - "prospects[0].title"

--- a/providers/manifests/people-enrich/explorium.yaml
+++ b/providers/manifests/people-enrich/explorium.yaml
@@ -1,68 +1,88 @@
 # Explorium AgentSource — people-enrich
 #
-# Vendor docs: https://docs.explorium.ai/reference/prospects/match_prospects
-# Endpoint:    POST /v1/prospects/match
-# Auth:        api_key header (static — no OAuth)
+# Vendor docs:
+#   https://docs.explorium.ai/reference/prospects/match_prospects
+#   https://docs.explorium.ai/reference/prospects/enrichments/contacts_information
+# Endpoints:
+#   1. POST /v1/prospects/match                              → prospect_id
+#   2. POST /v1/prospects/contacts_information/enrich        → email + phone
+# Auth:    api_key header (static — no OAuth)
 #
 # Resolves a contact (by email, LinkedIn URL, or name + company) to an
-# Explorium prospect_id and echoes back the identifying fields. The
-# prospect_id is the key for all downstream Explorium enrichment calls
-# (contacts_information, professional_profile, etc.).
+# Explorium prospect_id, then fetches verified contact details (professional
+# email + mobile phone) for that prospect. Returns the standard people-enrich
+# `results[]` shape with email, phone, linkedin_url, and a few extras.
 #
-# v1 scope and limitation:
-#   The DSL executes a single HTTP call. Explorium separates matching
-#   (POST /v1/prospects/match → prospect_id) from contact enrichment
-#   (POST /v1/prospects/contacts_information/enrich → emails, phones).
-#   This manifest covers the match step only. Returned email/linkedin fields
-#   are echoed from the caller's input, not new data fetched by Explorium.
-#   Full email + phone retrieval requires DSL multi-step support (planned
-#   for v2). Until then, use this adapter to resolve prospect_ids and pass
-#   them to the contacts_information endpoint outside YALC, or wait for v2.
+# This adapter uses the multi-step DSL: each step's projected output is
+# threaded into the next via {{steps.<id>.<path>}} placeholders.
 #
-# Input accepted per contact (contacts[0]):
-#   * email alone          → matched by email (highest accuracy)
-#   * linkedin_url alone   → matched by LinkedIn profile URL
-#   * firstname + lastname + company_name → matched by name + company
+# Input accepted (contacts[0]):
+#   * email          → matched by email (highest accuracy)
+#   * linkedin_url   → matched by LinkedIn profile URL
+#   * firstname + lastname + company_name → name + company match
 #   Providing more fetchers improves match accuracy.
 manifestVersion: 1
 capability: people-enrich
 provider: explorium
-version: 0.1.0
+version: 0.2.0
 auth:
   type: header
   name: api_key
   value: ${env:EXPLORIUM_API_KEY}
-endpoint:
-  method: POST
-  url: https://api.explorium.ai/v1/prospects/match
-request:
-  contentType: application/json
-  bodyTemplate: |
-    {
-      "prospects_to_match": [
+steps:
+  # Step 1: resolve the contact to an Explorium prospect_id.
+  - id: match
+    endpoint:
+      method: POST
+      url: https://api.explorium.ai/v1/prospects/match
+    request:
+      contentType: application/json
+      bodyTemplate: |
         {
-          "email": "{{input.contacts[0].domain}}",
-          "linkedin": "{{input.contacts[0].linkedin_url}}",
-          "full_name": "{{input.contacts[0].firstname}} {{input.contacts[0].lastname}}",
-          "company_name": "{{input.contacts[0].company_name}}"
+          "prospects_to_match": [
+            {
+              "email": "{{input.contacts[0].email}}",
+              "linkedin": "{{input.contacts[0].linkedin_url}}",
+              "full_name": "{{input.contacts[0].firstname}} {{input.contacts[0].lastname}}",
+              "company_name": "{{input.contacts[0].company_name}}"
+            }
+          ]
         }
-      ]
-    }
-response:
-  rootPath: matched_prospects
-  mappings:
-    "results[].email": "$.input.email"
-    "results[].linkedin_url": "$.input.linkedin"
-    "results[].company": "$.input.company_name"
-    "results[].prospect_id": "$.prospect_id"
-  errorEnvelope:
-    matchPath: $.details
-    messagePath: $.details
+    response:
+      rootPath: matched_prospects[0]
+      mappings:
+        "prospect_id": "$.prospect_id"
+      errorEnvelope:
+        matchPath: $.details
+        messagePath: $.details
+
+  # Step 2: enrich the prospect_id with contact details (email + phone).
+  - id: enrich
+    endpoint:
+      method: POST
+      url: https://api.explorium.ai/v1/prospects/contacts_information/enrich
+    request:
+      contentType: application/json
+      bodyTemplate: |
+        {
+          "prospect_id": "{{steps.match.prospect_id}}",
+          "parameters": {
+            "contact_types": ["email", "phone"]
+          }
+        }
+    response:
+      rootPath: data
+      mappings:
+        "results[].email": "$.professional_email"
+        "results[].phone": "$.mobile_phone"
+        "results[].emails": "$.emails"
+        "results[].phone_numbers": "$.phone_numbers"
+      errorEnvelope:
+        matchPath: $.details
+        messagePath: $.details
 smoke_test:
   input:
     contacts:
-      - firstname: Marc
-        lastname: Benioff
-        company_name: Salesforce
+      - email: "marc@salesforce.com"
   expectNonEmpty:
-    - "results[0].prospect_id"
+    - "results[0].email"

--- a/providers/manifests/people-enrich/explorium.yaml
+++ b/providers/manifests/people-enrich/explorium.yaml
@@ -1,0 +1,68 @@
+# Explorium AgentSource — people-enrich
+#
+# Vendor docs: https://docs.explorium.ai/reference/prospects/match_prospects
+# Endpoint:    POST /v1/prospects/match
+# Auth:        api_key header (static — no OAuth)
+#
+# Resolves a contact (by email, LinkedIn URL, or name + company) to an
+# Explorium prospect_id and echoes back the identifying fields. The
+# prospect_id is the key for all downstream Explorium enrichment calls
+# (contacts_information, professional_profile, etc.).
+#
+# v1 scope and limitation:
+#   The DSL executes a single HTTP call. Explorium separates matching
+#   (POST /v1/prospects/match → prospect_id) from contact enrichment
+#   (POST /v1/prospects/contacts_information/enrich → emails, phones).
+#   This manifest covers the match step only. Returned email/linkedin fields
+#   are echoed from the caller's input, not new data fetched by Explorium.
+#   Full email + phone retrieval requires DSL multi-step support (planned
+#   for v2). Until then, use this adapter to resolve prospect_ids and pass
+#   them to the contacts_information endpoint outside YALC, or wait for v2.
+#
+# Input accepted per contact (contacts[0]):
+#   * email alone          → matched by email (highest accuracy)
+#   * linkedin_url alone   → matched by LinkedIn profile URL
+#   * firstname + lastname + company_name → matched by name + company
+#   Providing more fetchers improves match accuracy.
+manifestVersion: 1
+capability: people-enrich
+provider: explorium
+version: 0.1.0
+auth:
+  type: header
+  name: api_key
+  value: ${env:EXPLORIUM_API_KEY}
+endpoint:
+  method: POST
+  url: https://api.explorium.ai/v1/prospects/match
+request:
+  contentType: application/json
+  bodyTemplate: |
+    {
+      "prospects_to_match": [
+        {
+          "email": "{{input.contacts[0].domain}}",
+          "linkedin": "{{input.contacts[0].linkedin_url}}",
+          "full_name": "{{input.contacts[0].firstname}} {{input.contacts[0].lastname}}",
+          "company_name": "{{input.contacts[0].company_name}}"
+        }
+      ]
+    }
+response:
+  rootPath: matched_prospects
+  mappings:
+    "results[].email": "$.input.email"
+    "results[].linkedin_url": "$.input.linkedin"
+    "results[].company": "$.input.company_name"
+    "results[].prospect_id": "$.prospect_id"
+  errorEnvelope:
+    matchPath: $.details
+    messagePath: $.details
+smoke_test:
+  input:
+    contacts:
+      - firstname: Marc
+        lastname: Benioff
+        company_name: Salesforce
+  expectNonEmpty:
+    - "results[0].prospect_id"

--- a/src/lib/providers/declarative/__tests__/compiler.test.ts
+++ b/src/lib/providers/declarative/__tests__/compiler.test.ts
@@ -271,4 +271,179 @@ pagination:
     // limit=5 means we collect 3 from page 1 + 2 from page 2 = 5
     expect(out.companies.map((c) => c.name)).toEqual(['a', 'b', 'c', 'd', 'e'])
   })
+
+  // ─── Multi-step manifests ─────────────────────────────────────────────────
+
+  describe('multi-step manifests', () => {
+    const MATCH_THEN_ENRICH = `
+manifestVersion: 1
+capability: people-enrich
+provider: explorium
+version: 0.1.0
+auth:
+  type: header
+  name: api_key
+  value: \${env:APOLLO_API_KEY}
+steps:
+  - id: match
+    endpoint:
+      method: POST
+      url: https://api.example.com/v1/match
+    request:
+      contentType: application/json
+      bodyTemplate: |
+        {"email": "{{input.email}}"}
+    response:
+      rootPath: matched[0]
+      mappings:
+        "prospect_id": "$.id"
+  - id: enrich
+    endpoint:
+      method: POST
+      url: https://api.example.com/v1/enrich
+    request:
+      contentType: application/json
+      bodyTemplate: |
+        {"id": "{{steps.match.prospect_id}}"}
+    response:
+      rootPath: data
+      mappings:
+        "results[].email": "$.professional_email"
+        "results[].phone": "$.mobile_phone"
+`
+
+    it('chains two HTTP calls and threads step output into the next request', async () => {
+      const calls: Array<{ url: string; body: any }> = []
+      const fetchImpl = (async (url: string, init: any) => {
+        calls.push({ url, body: JSON.parse(init.body) })
+        if (calls.length === 1) {
+          return jsonResponse({ matched: [{ id: 'pid-123' }] })
+        }
+        return jsonResponse({ data: [{ professional_email: 'jane@x.com', mobile_phone: '+15551234' }] })
+      }) as typeof fetch
+      const compiled = compileManifest(MATCH_THEN_ENRICH, 'inline', { fetchImpl })
+      const out = (await compiled.invoke({ email: 'jane@x.com' })) as { results: any[] }
+      expect(calls).toHaveLength(2)
+      expect(calls[0].url).toBe('https://api.example.com/v1/match')
+      expect(calls[0].body).toEqual({ email: 'jane@x.com' })
+      expect(calls[1].url).toBe('https://api.example.com/v1/enrich')
+      expect(calls[1].body).toEqual({ id: 'pid-123' })
+      expect(out.results[0]).toEqual({ email: 'jane@x.com', phone: '+15551234' })
+    })
+
+    it('applies the manifest auth to every step', async () => {
+      const headersSeen: Array<Record<string, string>> = []
+      const fetchImpl = (async (_url: string, init: any) => {
+        headersSeen.push(init.headers)
+        return jsonResponse(headersSeen.length === 1 ? { matched: [{ id: 'p1' }] } : { data: [{}] })
+      }) as typeof fetch
+      const compiled = compileManifest(MATCH_THEN_ENRICH, 'inline', { fetchImpl })
+      await compiled.invoke({ email: 'a@b.c' })
+      expect(headersSeen[0]['api_key']).toBe('test-key')
+      expect(headersSeen[1]['api_key']).toBe('test-key')
+    })
+
+    it('aborts the chain when an early step returns a vendor error', async () => {
+      const manifest = `
+manifestVersion: 1
+capability: people-enrich
+provider: explorium
+version: 0.1.0
+auth: { type: none }
+steps:
+  - id: match
+    endpoint:
+      method: POST
+      url: https://api.example.com/v1/match
+    response:
+      rootPath: matched[0]
+      mappings:
+        "prospect_id": "$.id"
+      errorEnvelope:
+        matchPath: $.error
+        messagePath: $.error
+  - id: enrich
+    endpoint:
+      method: POST
+      url: https://api.example.com/v1/enrich
+    response:
+      mappings:
+        "results[].email": "$.x"
+`
+      let calls = 0
+      const fetchImpl = (async () => {
+        calls++
+        return jsonResponse({ error: 'no match' })
+      }) as typeof fetch
+      const compiled = compileManifest(manifest, 'inline', { fetchImpl })
+      await expect(compiled.invoke({})).rejects.toMatchObject({
+        name: 'ProviderApiError',
+        message: expect.stringContaining('no match'),
+      })
+      // Second step must not run after the first errors out.
+      expect(calls).toBe(1)
+    })
+
+    it('rejects manifests with both top-level endpoint and steps', () => {
+      const bad = `
+manifestVersion: 1
+capability: foo
+provider: bar
+version: 0.1.0
+auth: { type: none }
+endpoint: { method: GET, url: https://x.com }
+response:
+  mappings: { "x": "$.x" }
+steps:
+  - id: a
+    endpoint: { method: GET, url: https://y.com }
+    response:
+      mappings: { "x": "$.x" }
+`
+      expect(() => compileManifest(bad, 'inline')).toThrow(ManifestValidationError)
+    })
+
+    it('rejects manifests with duplicate step ids at runtime', async () => {
+      const bad = `
+manifestVersion: 1
+capability: foo
+provider: bar
+version: 0.1.0
+auth: { type: none }
+steps:
+  - id: same
+    endpoint: { method: GET, url: https://x.com }
+    response:
+      mappings: { "v": "$.x" }
+  - id: same
+    endpoint: { method: GET, url: https://x.com }
+    response:
+      mappings: { "v": "$.x" }
+`
+      const fetchImpl = (async () => jsonResponse({ x: 1 })) as typeof fetch
+      const compiled = compileManifest(bad, 'inline', { fetchImpl })
+      await expect(compiled.invoke({})).rejects.toMatchObject({
+        name: 'ProviderApiError',
+        message: expect.stringContaining("duplicate step id 'same'"),
+      })
+    })
+
+    it('rejects unknown {{steps.*}} template references at compile time', () => {
+      const bad = `
+manifestVersion: 1
+capability: foo
+provider: bar
+version: 0.1.0
+auth: { type: none }
+steps:
+  - id: a
+    endpoint:
+      method: POST
+      url: https://x.com/{{bogus.field}}
+    response:
+      mappings: { "v": "$.x" }
+`
+      expect(() => compileManifest(bad, 'inline')).toThrow(/unknown template root/)
+    })
+  })
 })

--- a/src/lib/providers/declarative/compiler.ts
+++ b/src/lib/providers/declarative/compiler.ts
@@ -21,9 +21,12 @@ import schema from './schema.json' with { type: 'json' }
 import type {
   CompiledManifest,
   FetchLike,
+  ManifestEndpoint,
   ManifestPagination,
   ManifestRaw,
+  ManifestRequest,
   ManifestResponse,
+  ManifestStep,
 } from './types.js'
 import { ManifestValidationError } from './types.js'
 import { MissingApiKeyError, ProviderApiError } from '../adapters/index.js'
@@ -33,7 +36,7 @@ const validateManifest: ValidateFunction = ajv.compile(schema as object)
 
 const ENV_REF = /\$\{env:([A-Z0-9_]+)\}/g
 const PLACEHOLDER = /\{\{([^}]+)\}\}/g
-const ALLOWED_ROOTS = new Set(['input', 'env', 'auth'])
+const ALLOWED_ROOTS = new Set(['input', 'env', 'auth', 'steps'])
 
 export interface CompileOptions {
   /** Fetch override for tests. Defaults to `globalThis.fetch`. */
@@ -107,17 +110,28 @@ export function compileManifest(
 function collectTemplateStrings(m: ManifestRaw): string[] {
   const out: string[] = []
   if (m.auth?.value) out.push(m.auth.value)
-  out.push(m.endpoint.url)
-  if (m.endpoint.queryTemplate) {
-    for (const v of Object.values(m.endpoint.queryTemplate)) out.push(v)
-  }
-  if (m.request) {
-    if (m.request.bodyTemplate) out.push(m.request.bodyTemplate)
-    if (m.request.headers) {
-      for (const v of Object.values(m.request.headers)) out.push(v)
-    }
+  if (m.endpoint) collectEndpointTemplates(m.endpoint, m.request, out)
+  if (m.steps) {
+    for (const step of m.steps) collectEndpointTemplates(step.endpoint, step.request, out)
   }
   return out
+}
+
+function collectEndpointTemplates(
+  endpoint: ManifestEndpoint,
+  request: ManifestRequest | undefined,
+  out: string[],
+): void {
+  out.push(endpoint.url)
+  if (endpoint.queryTemplate) {
+    for (const v of Object.values(endpoint.queryTemplate)) out.push(v)
+  }
+  if (request) {
+    if (request.bodyTemplate) out.push(request.bodyTemplate)
+    if (request.headers) {
+      for (const v of Object.values(request.headers)) out.push(v)
+    }
+  }
 }
 
 function parseExprRoot(expr: string): string {
@@ -153,12 +167,26 @@ async function executeManifest(
   if (m.auth.name) authScope.name = m.auth.name
   authScope.type = m.auth.type
 
-  const scope = { input: input ?? {}, env: envScope, auth: authScope }
+  const scope: TemplateScope = {
+    input: input ?? {},
+    env: envScope,
+    auth: authScope,
+    steps: {},
+  }
 
+  if (m.steps && m.steps.length > 0) {
+    return executeSteps(m, scope, fetchImpl, m.steps)
+  }
+  if (!m.endpoint || !m.response) {
+    throw new ProviderApiError(
+      m.provider,
+      'manifest is missing both top-level endpoint/response and a steps[] array',
+    )
+  }
   if (m.pagination) {
     return executePaginated(m, scope, fetchImpl, m.pagination)
   }
-  return executeOnce(m, scope, fetchImpl)
+  return executeOnce(m.endpoint, m.request, m.response, m.provider, scope, fetchImpl, m.auth)
 }
 
 function collectEnvRefs(m: ManifestRaw): string[] {
@@ -170,21 +198,25 @@ function collectEnvRefs(m: ManifestRaw): string[] {
 }
 
 async function executeOnce(
-  m: ManifestRaw,
+  endpoint: ManifestEndpoint,
+  request: ManifestRequest | undefined,
+  response: ManifestResponse,
+  providerId: string,
   scope: TemplateScope,
   fetchImpl: FetchLike,
+  authSpec?: { type: string; name?: string; value?: string },
 ): Promise<unknown> {
-  const { url, headers, body } = buildRequest(m, scope)
+  const { url, headers, body } = buildRequest(endpoint, request, authSpec, scope)
   let res: Response
   try {
     res = await fetchImpl(url, {
-      method: m.endpoint.method,
+      method: endpoint.method,
       headers,
       body,
     })
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
-    throw new ProviderApiError(m.provider, `network error: ${msg}`)
+    throw new ProviderApiError(providerId, `network error: ${msg}`)
   }
 
   let parsed: unknown = null
@@ -198,32 +230,73 @@ async function executeOnce(
   }
 
   if (!res.ok) {
-    const message = extractErrorMessage(m.response.errorEnvelope?.messagePath, parsed) ??
+    const message = extractErrorMessage(response.errorEnvelope?.messagePath, parsed) ??
       `HTTP ${res.status}`
-    throw new ProviderApiError(m.provider, message, res.status)
+    throw new ProviderApiError(providerId, message, res.status)
   }
-  if (matchesErrorEnvelope(m.response, parsed)) {
-    const message = extractErrorMessage(m.response.errorEnvelope?.messagePath, parsed) ?? 'vendor error'
-    throw new ProviderApiError(m.provider, message, res.status)
+  if (matchesErrorEnvelope(response, parsed)) {
+    const message = extractErrorMessage(response.errorEnvelope?.messagePath, parsed) ?? 'vendor error'
+    throw new ProviderApiError(providerId, message, res.status)
   }
 
-  return projectMappings(m.response, parsed)
+  return projectMappings(response, parsed)
+}
+
+/**
+ * Execute a chain of HTTP calls. Each step's projected output is
+ * accumulated into `scope.steps[id]` so subsequent steps can reference
+ * earlier step output via `{{steps.<id>.<path>}}` placeholders. The final
+ * step's projected output is the manifest's return value.
+ *
+ * Step ids must be unique within a manifest (enforced here, not in the
+ * JSON schema, so we get a useful error message that names the duplicate).
+ */
+async function executeSteps(
+  m: ManifestRaw,
+  scope: TemplateScope,
+  fetchImpl: FetchLike,
+  steps: ManifestStep[],
+): Promise<unknown> {
+  const seen = new Set<string>()
+  let lastOutput: unknown = null
+  for (const step of steps) {
+    if (seen.has(step.id)) {
+      throw new ProviderApiError(m.provider, `duplicate step id '${step.id}'`)
+    }
+    seen.add(step.id)
+    const projected = await executeOnce(
+      step.endpoint,
+      step.request,
+      step.response,
+      m.provider,
+      scope,
+      fetchImpl,
+      m.auth,
+    )
+    scope.steps[step.id] = projected
+    lastOutput = projected
+  }
+  return lastOutput
 }
 
 interface TemplateScope {
   input: unknown
   env: Record<string, string>
   auth: Record<string, string>
+  /** Projected outputs from prior steps in a multi-step manifest, keyed by step id. */
+  steps: Record<string, unknown>
 }
 
 function buildRequest(
-  m: ManifestRaw,
+  endpoint: ManifestEndpoint,
+  request: ManifestRequest | undefined,
+  authSpec: { type: string; name?: string; value?: string } | undefined,
   scope: TemplateScope,
 ): { url: string; headers: Record<string, string>; body: string | undefined } {
-  let url = renderTemplate(m.endpoint.url, scope)
-  if (m.endpoint.queryTemplate) {
+  let url = renderTemplate(endpoint.url, scope)
+  if (endpoint.queryTemplate) {
     const qs = new URLSearchParams()
-    for (const [k, v] of Object.entries(m.endpoint.queryTemplate)) {
+    for (const [k, v] of Object.entries(endpoint.queryTemplate)) {
       const rendered = renderTemplate(v, scope)
       if (rendered !== '') qs.set(k, rendered)
     }
@@ -234,26 +307,28 @@ function buildRequest(
   }
 
   const headers: Record<string, string> = {}
-  if (m.request?.headers) {
-    for (const [k, v] of Object.entries(m.request.headers)) {
+  if (request?.headers) {
+    for (const [k, v] of Object.entries(request.headers)) {
       headers[k] = renderTemplate(v, scope)
     }
   }
 
-  // Auth header injection
-  if (m.auth.type === 'header' && m.auth.name && m.auth.value !== undefined) {
-    headers[m.auth.name] = renderEnvRefs(m.auth.value, scope.env)
-  } else if (m.auth.type === 'bearer' && m.auth.value !== undefined) {
-    headers['Authorization'] = `Bearer ${renderEnvRefs(m.auth.value, scope.env)}`
-  } else if (m.auth.type === 'query' && m.auth.name && m.auth.value !== undefined) {
-    const qsAdd = `${encodeURIComponent(m.auth.name)}=${encodeURIComponent(renderEnvRefs(m.auth.value, scope.env))}`
-    url += url.includes('?') ? `&${qsAdd}` : `?${qsAdd}`
+  // Auth header injection (applies to every step in a multi-step manifest)
+  if (authSpec) {
+    if (authSpec.type === 'header' && authSpec.name && authSpec.value !== undefined) {
+      headers[authSpec.name] = renderEnvRefs(authSpec.value, scope.env)
+    } else if (authSpec.type === 'bearer' && authSpec.value !== undefined) {
+      headers['Authorization'] = `Bearer ${renderEnvRefs(authSpec.value, scope.env)}`
+    } else if (authSpec.type === 'query' && authSpec.name && authSpec.value !== undefined) {
+      const qsAdd = `${encodeURIComponent(authSpec.name)}=${encodeURIComponent(renderEnvRefs(authSpec.value, scope.env))}`
+      url += url.includes('?') ? `&${qsAdd}` : `?${qsAdd}`
+    }
   }
 
   let body: string | undefined
-  if (m.request?.bodyTemplate) {
-    if (m.request.contentType) headers['Content-Type'] ??= m.request.contentType
-    body = renderTemplate(m.request.bodyTemplate, scope)
+  if (request?.bodyTemplate) {
+    if (request.contentType) headers['Content-Type'] ??= request.contentType
+    body = renderTemplate(request.bodyTemplate, scope)
   }
 
   return { url, headers, body }
@@ -323,6 +398,7 @@ function readPath(path: string, scope: TemplateScope): unknown {
   if (root === 'input') base = scope.input
   else if (root === 'env') base = scope.env
   else if (root === 'auth') base = scope.auth
+  else if (root === 'steps') base = scope.steps
   else return undefined
   // remainder is everything after the root
   const rest = path.slice(root.length)
@@ -491,6 +567,12 @@ async function executePaginated(
   fetchImpl: FetchLike,
   pag: ManifestPagination,
 ): Promise<Record<string, unknown>> {
+  if (!m.endpoint || !m.response) {
+    throw new ProviderApiError(
+      m.provider,
+      'pagination requires top-level endpoint/response (multi-step + pagination not supported in v1)',
+    )
+  }
   // Page state injected as scope.input.__page__ / __cursor__
   const merged: Record<string, unknown[]> = {}
   let scalarSeed: Record<string, unknown> | null = null
@@ -505,7 +587,15 @@ async function executePaginated(
       __cursor__: cursor,
     }
     const pagedScope: TemplateScope = { ...scope, input: pagedInput }
-    const projected = (await executeOnce(m, pagedScope, fetchImpl)) as Record<string, unknown>
+    const projected = (await executeOnce(
+      m.endpoint,
+      m.request,
+      m.response,
+      m.provider,
+      pagedScope,
+      fetchImpl,
+      m.auth,
+    )) as Record<string, unknown>
     if (scalarSeed === null) {
       scalarSeed = {}
       for (const [k, v] of Object.entries(projected)) {

--- a/src/lib/providers/declarative/schema.json
+++ b/src/lib/providers/declarative/schema.json
@@ -8,9 +8,7 @@
     "capability",
     "provider",
     "version",
-    "auth",
-    "endpoint",
-    "response"
+    "auth"
   ],
   "properties": {
     "manifestVersion": { "type": "integer", "enum": [1] },
@@ -73,6 +71,25 @@
         }
       }
     },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "endpoint", "response"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+            "description": "Step identifier — referenced by later steps as {{steps.<id>.<path>}}"
+          },
+          "endpoint": { "$ref": "#/properties/endpoint" },
+          "request": { "$ref": "#/properties/request" },
+          "response": { "$ref": "#/properties/response" }
+        }
+      }
+    },
     "pagination": {
       "type": "object",
       "additionalProperties": false,
@@ -107,5 +124,31 @@
         }
       }
     }
-  }
+  },
+  "oneOf": [
+    {
+      "description": "Single-step manifest: endpoint + response at the top level",
+      "required": ["endpoint", "response"],
+      "not": { "required": ["steps"] }
+    },
+    {
+      "description": "Multi-step manifest: a `steps` array with no top-level endpoint/request/response",
+      "required": ["steps"],
+      "not": {
+        "anyOf": [
+          { "required": ["endpoint"] },
+          { "required": ["request"] },
+          { "required": ["response"] }
+        ]
+      },
+      "allOf": [
+        {
+          "not": {
+            "required": ["pagination"],
+            "description": "Pagination is incompatible with multi-step manifests in v1"
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/src/lib/providers/declarative/types.ts
+++ b/src/lib/providers/declarative/types.ts
@@ -54,15 +54,30 @@ export interface ManifestSmokeTest {
   expectNonEmpty?: string[]
 }
 
+/**
+ * One HTTP call inside a multi-step manifest. The step's projected output
+ * (after `response.mappings`) is exposed to subsequent steps via the
+ * `{{steps.<id>.<path>}}` template root.
+ */
+export interface ManifestStep {
+  id: string
+  endpoint: ManifestEndpoint
+  request?: ManifestRequest
+  response: ManifestResponse
+}
+
 export interface ManifestRaw {
   manifestVersion: number
   capability: string
   provider: string
   version: string
   auth: ManifestAuth
-  endpoint: ManifestEndpoint
+  /** Single-step manifest: top-level endpoint/request/response. Mutually exclusive with `steps`. */
+  endpoint?: ManifestEndpoint
   request?: ManifestRequest
-  response: ManifestResponse
+  response?: ManifestResponse
+  /** Multi-step manifest: a chain of HTTP calls. Mutually exclusive with top-level endpoint/request/response. */
+  steps?: ManifestStep[]
   pagination?: ManifestPagination
   rateLimit?: Record<string, unknown>
   smoke_test?: ManifestSmokeTest


### PR DESCRIPTION
## Summary

Two changes in one PR:

1. **Engine: multi-step declarative adapters.** The DSL was single-call by design (one HTTP request per adapter). That blocks vendors whose canonical flow is match-then-enrich (Explorium, Apollo's people enrich, etc.). This PR adds a top-level `steps` array — a linear chain of HTTP calls where each step's projected output is threaded into the next via `{{steps.<id>.<path>}}` placeholders.
2. **Providers: Explorium AgentSource manifests** for all four GTM data pillars (company search, prospect search, prospect enrich, business enrich). Two of them now use the new `steps` syntax to express the real Explorium flow.

All 54 declarative tests pass (14 pre-existing + 40 across the rest of the suite + 6 new for multi-step). All 8 provider manifests validate.

---

## Engine change: `steps` array

**New manifest shape (mutually exclusive with single-call):**

```yaml
steps:
  - id: match
    endpoint: { method: POST, url: https://api.explorium.ai/v1/prospects/match }
    request:
      contentType: application/json
      bodyTemplate: |
        { "prospects_to_match": [ { "email": "{{input.contacts[0].email}}" } ] }
    response:
      rootPath: matched_prospects[0]
      mappings:
        "prospect_id": "$.prospect_id"
  - id: enrich
    endpoint: { method: POST, url: https://api.explorium.ai/v1/prospects/contacts_information/enrich }
    request:
      contentType: application/json
      bodyTemplate: |
        { "prospect_id": "{{steps.match.prospect_id}}" }
    response:
      rootPath: data
      mappings:
        "results[].email": "$.professional_email"
        "results[].phone": "$.mobile_phone"
```

**Semantics:**

- Steps execute sequentially. Each step's projection is stored at `scope.steps.<id>` and is visible to all later steps (and only later steps).
- The auth block applies to every step.
- A non-2xx HTTP status OR an `errorEnvelope` match aborts the chain — later steps don't run.
- Step ids must be unique; duplicates fail at runtime with a clear message.
- `pagination` is incompatible with `steps` in v1 (compiler rejects it).
- Loops, conditionals, and parallel fan-out are explicitly out of scope. The chain is strictly linear — same constraint Apollo's compose pattern uses.

**Files touched in the engine:**

| File | Change |
|------|--------|
| `src/lib/providers/declarative/schema.json` | `oneOf` constraint enforcing single-call XOR multi-step shape; new `steps` array def referencing the existing endpoint/request/response sub-schemas |
| `src/lib/providers/declarative/types.ts` | `ManifestStep` interface; `endpoint`/`request`/`response` become optional on `ManifestRaw`; `steps?` added |
| `src/lib/providers/declarative/compiler.ts` | `executeSteps` walks the chain; `executeOnce` refactored to take explicit endpoint/request/response/auth so it serves both the legacy path and each step; `TemplateScope.steps` and `readPath('steps')` plumbed through |
| `src/lib/providers/declarative/__tests__/compiler.test.ts` | 6 new tests: happy path, auth on every step, error abort, schema rejection of mixed shapes, duplicate id detection, unknown template root rejection |
| `docs/superpowers/specs/2026-05-01-declarative-adapters-design.md` | Example D (Explorium multi-step) + semantics doc |
| `providers/CONTRIBUTING.md` | "no multi-step flows" rule removed |

**Backward compatibility:** every existing manifest (Apollo, PDL, HubSpot, Brevo, Vercel) still validates and runs unchanged. The new shape is opt-in.

---

## Provider change: Explorium AgentSource (4 manifests)

| File | Capability | Endpoint(s) | Shape |
|------|-----------|------------|-------|
| `icp-company-search/explorium.yaml` | `icp-company-search` | `POST /v1/businesses` | single-call |
| `people-enrich/explorium.yaml` | `people-enrich` | `match` → `contacts_information/enrich` | **multi-step** |
| `icp-prospect-search/explorium.yaml` | `icp-prospect-search` (new) | `POST /v1/prospects` | single-call |
| `business-enrich/explorium.yaml` | `business-enrich` (new) | `match` → `firmographics/enrich` | **multi-step** |

`icp-prospect-search` and `business-enrich` are proposed new capabilities. Each manifest header describes the input/output schema; a companion engine PR is needed to register them in `src/lib/providers/adapters/index.ts`.

---

## PR checklist

- [x] `node providers/scripts/validate.mjs` exits 0 locally (8/8 manifests)
- [x] All declarative tests pass (`npx vitest run src/lib/providers/declarative/`: 54/54)
- [ ] Smoke ran green locally — requires `EXPLORIUM_API_KEY`; maintainer smoke run needed
- [x] No secrets inlined — all credentials reference `${env:EXPLORIUM_API_KEY}`
- [x] No existing manifest on `main` for any of the four `(capability, provider)` pairs
- [x] Vendor docs URL: https://docs.explorium.ai/reference

## Validate output

```
✓ providers/manifests/business-enrich/explorium.yaml
✓ providers/manifests/crm-contact-upsert/hubspot.yaml
✓ providers/manifests/email-campaign-create/brevo.yaml
✓ providers/manifests/icp-company-search/apollo.yaml
✓ providers/manifests/icp-company-search/explorium.yaml
✓ providers/manifests/icp-prospect-search/explorium.yaml
✓ providers/manifests/people-enrich/explorium.yaml
✓ providers/manifests/people-enrich/peopledatalabs.yaml

8 manifest(s) validated.
```

## Required env var

```
EXPLORIUM_API_KEY=<your Explorium API key>
```

API keys are at [admin.explorium.ai](https://admin.explorium.ai) under **Access & Authentication → Getting Your API Key**.